### PR TITLE
Mermaid `parse()` fails on flowcharts generated for complex ontologies

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -4,6 +4,5 @@ ignores: [
     'rimraf',
     '@kitajs/ts-html-plugin',
     'htmx-ext-json-enc',
-    'mermaid',
     'htmx.org'
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "express": "^4.21.1",
         "htmx-ext-json-enc": "^2.0.1",
         "htmx.org": "^1.9.12",
-        "mermaid": "^11.3.0",
         "pino": "^9.5.0",
         "pino-http": "^10.3.0",
         "puppeteer": "^23.6.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "express": "^4.21.1",
     "htmx-ext-json-enc": "^2.0.1",
     "htmx.org": "^1.9.12",
-    "mermaid": "^11.3.0",
     "pino": "^9.5.0",
     "pino-http": "^10.3.0",
     "puppeteer": "^23.6.0",

--- a/src/lib/server/utils/mermaid/__tests__/generator.test.ts
+++ b/src/lib/server/utils/mermaid/__tests__/generator.test.ts
@@ -18,21 +18,20 @@ describe('Generator', () => {
 
   describe('mermaidMarkdownByChartType', () => {
     it('should return a svg for a simple dtdl model', () => {
-      const markdown = generator.mermaidMarkdownByChartType(simpleMockDtdlObjectModel, 'flowchart')
+      const markdown = generator.mermaidMarkdownByChartType['flowchart'](simpleMockDtdlObjectModel)
       expect(markdown).to.equal(flowchartFixtureSimple)
     })
 
     it('should return a svg for a simple dtdl model with highlighted node', () => {
-      const markdown = generator.mermaidMarkdownByChartType(
+      const markdown = generator.mermaidMarkdownByChartType['flowchart'](
         simpleMockDtdlObjectModel,
-        'flowchart',
         'dtmi:com:example:1'
       )
       expect(markdown).to.equal(flowchartFixtureSimpleHighlighted)
     })
 
     it('should return null for empty object model', () => {
-      const markdown = generator.mermaidMarkdownByChartType({}, 'flowchart', 'dtmi:com:example:1')
+      const markdown = generator.mermaidMarkdownByChartType['flowchart']({}, 'dtmi:com:example:1')
       expect(markdown).to.equal(null)
     })
   })

--- a/src/lib/server/utils/mermaid/generator.ts
+++ b/src/lib/server/utils/mermaid/generator.ts
@@ -14,15 +14,12 @@ export class SvgGenerator {
     this.browser = puppeteer.launch({})
   }
 
-  mermaidMarkdownByChartType(
-    dtdlObject: DtdlObjectModel,
-    chartType: ChartTypes,
-    highlightNodeId?: MermaidId
-  ): string | null {
-    const chartTypeHandlers = {
-      flowchart: () => this.flowchart.getFlowchartMarkdown(dtdlObject, Direction.TopToBottom, highlightNodeId),
-    }
-    return chartTypeHandlers[chartType]()
+  mermaidMarkdownByChartType: Record<
+    ChartTypes,
+    (dtdlObject: DtdlObjectModel, highlightNodeId?: MermaidId) => string | null
+  > = {
+    flowchart: (dtdlObject, highlightNodeId) =>
+      this.flowchart.getFlowchartMarkdown(dtdlObject, Direction.TopToBottom, highlightNodeId),
   }
 
   async run(dtdlObject: DtdlObjectModel, params: QueryParams, options: ParseMDDOptions = {}): Promise<string> {
@@ -40,7 +37,8 @@ export class SvgGenerator {
         layout: params.layout,
       },
     }
-    const graph = this.mermaidMarkdownByChartType(dtdlObject, params.chartType, params.highlightNodeId)
+
+    const graph = this.mermaidMarkdownByChartType[params.chartType](dtdlObject, params.highlightNodeId)
     if (!graph) return 'No graph'
 
     const { data } = await renderMermaid(await this.browser, graph, params.output, parseMDDOptions)


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-41

## High level description

The generated mermaid flowchart string is validated with `mermaid.parse()`, which fails on more complex (but still valid) graphs with `TypeError: DOMPurify.addHook is not a function` - which comes from mermaid now being run on the backend. Short term solution is to remove `mermaid.parse()`

## Describe alternatives you've considered

Use `mermaid.parse()` to test the Flowchart class at test time rather than run time. For a future PR.

