### PR TITLE
Fix htmx swapping after upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.57",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {

--- a/public/scripts/callbacks.js
+++ b/public/scripts/callbacks.js
@@ -1,5 +1,4 @@
 let panZoom = null
-const contentMain = document.querySelector('#content-main')
 
 const minimapStyles = window.getComputedStyle(document.getElementById('minimap'))
 const desiredAspectRatio = parseFloat(minimapStyles.width) / parseFloat(minimapStyles.height)
@@ -112,10 +111,11 @@ function setSizes() {
 }
 
 function setMinimap() {
+  const contentMain = document.querySelector('#content-main')
   const mainSvg = document.querySelector('#mermaid-output #mermaid-svg')
   const mainViewport = document.querySelector('#mermaid-output .svg-pan-zoom_viewport')
 
-  if (!(mainSvg && mainViewport)) return
+  if (!(contentMain && mainSvg && mainViewport)) return
 
   const { width: viewportSvgWidth, height: viewportSvgHeight } = mainSvg.getBoundingClientRect()
   const { width: rawSvgWidth, height: rawSvgHeight } = mainViewport.getBBox()

--- a/src/lib/server/controllers/root.ts
+++ b/src/lib/server/controllers/root.ts
@@ -170,6 +170,7 @@ export class RootController extends HTMLController {
         expanded: newSession.highlightNodeId !== undefined,
       }),
       this.templates.svgControls({
+        swapOutOfBand: true,
         generatedOutput: output.renderForMinimap(),
       })
     )

--- a/src/lib/server/views/components/mermaid.tsx
+++ b/src/lib/server/views/components/mermaid.tsx
@@ -65,10 +65,16 @@ export default class MermaidTemplates {
     </Page>
   )
 
-  public svgControls = ({ generatedOutput }: { generatedOutput?: JSX.Element }): JSX.Element => {
+  public svgControls = ({
+    generatedOutput,
+    swapOutOfBand,
+  }: {
+    generatedOutput?: JSX.Element
+    swapOutOfBand?: boolean
+  }): JSX.Element => {
     const output = generatedOutput ?? ''
     return (
-      <div id="svg-controls" hx-swap-oob="true">
+      <div id="svg-controls" hx-swap-oob={swapOutOfBand ? 'true' : undefined}>
         <div id="minimap">{output && <div id="minimap-svg">{output}</div>}</div>
         <div id="zoom-buttons">
           <button id="zoom-in">+</button>

--- a/src/lib/server/views/components/mermaid.tsx
+++ b/src/lib/server/views/components/mermaid.tsx
@@ -349,6 +349,7 @@ export default class MermaidTemplates {
         hx-ext="ignore:json-enc"
         hx-target="#content-main"
         hx-select="#content-main"
+        hx-swap="outerHTML"
         hx-post="/upload"
         hx-encoding="multipart/form-data"
         hx-trigger="change from:#upload"


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-69
https://digicatapult.atlassian.net/browse/NIDT-83

## High level description

After upload of a valid zipped DTDL, the page does an `/update-layout` and `callbacks.js` throws an error because there’s no `svg-controls` div. This is because the `hx-swap-oob` attribute was being included on `svg-controls` in the initial page load of `MermaidRoot` by `/`, when it should only be included on subsequent returns by `/update-layout`. 

Additionally, the `#content-main` swap on upload was using inner rather than outer html so the replacement `#content-main` div was nesting inside the original. Changed to outerHTML so the element is completely swapped correctly.

