### PR TITLE
Add DockerHub secrets to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,9 @@ jobs:
     permissions:
       packages: write
       contents: write
+    secrets:
+      DOCKERHUB_TOKEN: ${{ secrets.SQNC_DOCKERHUB_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ secrets.SQNC_DOCKERHUB_USERNAME }}
 
   release-github:
     needs: [build-docker]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.65",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets
https://digicatapult.atlassian.net/browse/NIDT-70

## High level description

Release was missing dockerhub secrets so failing on push e.g. https://github.com/digicatapult/dtdl-visualisation-tool/actions/runs/13001788275/job/36261880311
