### PR TITLE
Remove catching of errors on start up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.73",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ import { container } from 'tsyringe'
 import Database from './lib/db/index.js'
 import { httpServer } from './lib/server/index.js'
 import { logger } from './lib/server/logger.js'
-import { type UUID } from './lib/server/models/strings.js'
 import { DtdlLoader } from './lib/server/utils/dtdl/dtdlLoader.js'
 import { parseAndInsertDtdl } from './lib/server/utils/dtdl/parse.js'
 import { SvgGenerator } from './lib/server/utils/mermaid/generator.js'
@@ -44,13 +43,7 @@ program
     const db = container.resolve(Database)
     logger.info(`Storing default model in db`)
 
-    let id: UUID
-    try {
-      id = await parseAndInsertDtdl(options.path, `default`, db)
-    } catch {
-      logger.error(`Error parsing DTDL`)
-      process.exit(1)
-    }
+    const id = await parseAndInsertDtdl(options.path, `default`, db)
 
     const dtdlLoader = new DtdlLoader(db, id)
     container.register(DtdlLoader, {


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix


## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-74

## High level description

We don't want to catch and ignore all errors of parsing+inserting the DTDL at startup. I'm currently trying to get the tool to connect to a database in Azure and need to see why the connection is failing