### PR TITLE
Add startup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV CHROME_PUPPETEER_PATH=/usr/bin/chromium
 
 COPY sample ./sample
+COPY scripts ./scripts
 
 RUN apt-get update && apt-get install -y chromium --no-install-recommends
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.23",
+      "version": "0.4.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.78",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+npx knex migrate:latest --env production
+dtdl-visualiser parse -p /sample/energygrid


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-74

## High level description

Add a script to be executed at startup in deployment so migration always runs before the app starts. Azure was failing to run variations of `/bin/sh -c 'npx knex migrate:latest --env production && dtdl-visualiser parse -p /sample/energygrid'` throwing `knex: 1: Syntax error: Unterminated quoted string`, even though the two commands work fine separately. Using a script should mean we can reliably run multiple commands.


## Describe alternatives you've considered

Add `npx knex migrate:latest --env production` to the dockerfile `CMD`