### PR TITLE
Fix bug where long names are split over multiple spans and then don't get htmx attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.24",
+      "version": "0.4.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.78",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {

--- a/src/lib/server/utils/mermaid/__tests__/svgMutator.test.ts
+++ b/src/lib/server/utils/mermaid/__tests__/svgMutator.test.ts
@@ -205,6 +205,34 @@ describe('Generator', function () {
       expect(label.hasAttribute('clickable')).to.equal(true)
     })
 
+    it('should return an element with htmx attributes if it is in the relationship map but with a long name', () => {
+      const labelInner1 = document.createElement('text')
+      const labelInner2 = document.createElement('text')
+      labelInner1.classList.add('text-inner-tspan')
+      labelInner2.classList.add('text-inner-tspan')
+      labelInner1.innerHTML = 'bar'
+      labelInner2.innerHTML = 'long'
+
+      const label = document.createElement('g')
+      label.appendChild(labelInner1)
+      label.appendChild(labelInner2)
+
+      const line = document.createElement('g')
+      line.id = 'test_foo_1_2_3'
+
+      const relationshipMap = new Map([['foo_barlong', 'baz']])
+
+      mutator.setEdgeAttributes(line, label, relationshipMap)
+
+      expect(label.getAttribute('hx-get')).to.equal('update-layout')
+      expect(label.getAttribute('hx-target')).to.equal('#mermaid-output')
+      expect(label.getAttribute('hx-swap')).to.equal('outerHTML transition:true')
+      expect(label.getAttribute('hx-indicator')).to.equal('#spinner')
+      expect(label.getAttribute('hx-vals')).to.equal(JSON.stringify({ highlightNodeId: 'baz' }))
+
+      expect(label.hasAttribute('clickable')).to.equal(true)
+    })
+
     it('should set highlighted node if it matches', () => {
       const labelInner = document.createElement('text')
       labelInner.classList.add('text-inner-tspan')

--- a/src/lib/server/utils/mermaid/svgMutator.ts
+++ b/src/lib/server/utils/mermaid/svgMutator.ts
@@ -97,7 +97,7 @@ export class SvgMutator {
     relationshipMap: Map<string, string>,
     highlighNodeId?: string
   ) {
-    const labelText = labelElement.querySelector('.text-inner-tspan')?.innerHTML
+    const labelText = [...labelElement.querySelectorAll('.text-inner-tspan')].map((n) => n.innerHTML).join('')
     const relationshipId = relationshipMap.get(`${this.getMermaidIdFromId(lineElement.id, 'edge')}_${labelText}`)
 
     if (!relationshipId) {


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-93

## High level description

Fixes on click handling for relationships with long names

## Detailed description

Relationships with long names have their displayed name split over multiple spans. This causes the lookup of the dtdl to fail as the names aren't as expected. This change fixes that by joining the string contents together.

## Describe alternatives you've considered

N/A

## Operational impact

None

## Additional context

None
