### PR TITLE
Change `GH_REDIRECT_URI` env to `GH_REDIRECT_ORIGIN` + envalid str

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The application can be run in Docker. `sample/energygrid` is automatically parse
 | GH_CLIENT_ID        | y        | -                         | See [GitHub Integration](#github-integration)                                                                                                |
 | GH_CLIENT_SECRET    | y        | -                         | See [GitHub Integration](#github-integration)                                                                                                |
 | GH_PER_PAGE         | n        | `50`                      | The number of results per GitHub API request (max 100)                                                                                       |
-| GH_REDIRECT_URI     | n        | `http://localhost:3000`   | URI to redirect to for GitHub OAuth callback. See [GitHub Integration](#github-integration)                                                  |
+| GH_REDIRECT_ORIGIN  | n        | `http://localhost:3000`   | Origin to redirect to for GitHub OAuth callback. See [GitHub Integration](#github-integration)                                               |
 | COOKIE_SESSION_KEYS | y        | -                         | Secret for signed cookies, devDefault `secret`                                                                                               |
 | PUPPETEER_ARGS      | n        | ''                        | Comma separated string of puppeteer [launch args](https://pptr.dev/api/puppeteer.launchoptions) e.g. `--no-sandbox,--disable-setuid-sandbox` |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.27",
+      "version": "0.4.28",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.78",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.28",
+      "version": "0.4.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.78",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {

--- a/src/lib/server/controllers/__tests__/github.test.ts
+++ b/src/lib/server/controllers/__tests__/github.test.ts
@@ -138,7 +138,7 @@ describe('GithubController', async () => {
       const setHeaderSpy = sinon.spy(controller, 'setHeader')
       const setStatusSpy = sinon.spy(controller, 'setStatus')
       const redirect = encodeURIComponent(
-        `${env.get('GH_REDIRECT_URI')}/github/callback?sessionId=${noOctokitSessionId}`
+        `${env.get('GH_REDIRECT_ORIGIN')}/github/callback?sessionId=${noOctokitSessionId}`
       )
 
       await controller.picker(mockReqWithCookie({}), noOctokitSessionId)

--- a/src/lib/server/controllers/github.ts
+++ b/src/lib/server/controllers/github.ts
@@ -58,7 +58,7 @@ export class GithubController extends HTMLController {
   async getOctokitToken(sessionId: string, returnUrl: string): Promise<void> {
     this.sessionStore.update(sessionId, { returnUrl })
 
-    const callback = safeUrl(`${env.get('GH_REDIRECT_URI')}/github/callback`, { sessionId })
+    const callback = safeUrl(`${env.get('GH_REDIRECT_ORIGIN')}/github/callback`, { sessionId })
     const githubAuthUrl = safeUrl(`https://github.com/login/oauth/authorize`, {
       client_id: env.get('GH_CLIENT_ID'),
       redirect_uri: callback,

--- a/src/lib/server/env/index.ts
+++ b/src/lib/server/env/index.ts
@@ -25,7 +25,7 @@ const envConfig = {
   GH_CLIENT_SECRET: envalid.str(),
   GH_PER_PAGE: envalid.num({ default: 50 }),
   UPLOAD_LIMIT_MB: envalid.num({ default: 10 }),
-  GH_REDIRECT_URI: envalid.host({ default: 'http://localhost:3000' }),
+  GH_REDIRECT_ORIGIN: envalid.str({ default: 'http://localhost:3000' }),
   PUPPETEER_ARGS: strArrayValidator({ default: [''] }),
 }
 


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-74

## High level description

Envalid was failing for strings like`http://localhost:3000`  , because it was validating for a host string. Origin is a more accurate name.
