### PR TITLE
Add workflow concurrency rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
 
   e2e-tests-npm:
     uses: digicatapult/shared-workflows/.github/workflows/tests-e2e-npm.yml@main
+    concurrency:
+      group: e2e-tests-npm
+      cancel-in-progress: true
     with:
       docker_compose_file: ''
       pre_test_command: 'npm ci && npx playwright install-deps && npx playwright install'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches-ignore: ['main']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   static-checks-npm:
     uses: digicatapult/shared-workflows/.github/workflows/static-checks-npm.yml@main
@@ -23,6 +27,8 @@ jobs:
 
   e2e-tests-npm:
     uses: digicatapult/shared-workflows/.github/workflows/tests-e2e-npm.yml@main
+    concurrency:
+      group: e2e-tests-npm
     with:
       docker_compose_file: ''
       pre_test_command: 'npm ci && npx playwright install-deps && npx playwright install'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.27",
+      "version": "0.4.28",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.78",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

<!-- If this PR is linked to a JIRA ticket or Github Issue, please provide the ticket URL here. -->

## High level description

We are regularly hitting the GitHub login rate limit for the GitHub OAuth e2e test, especially bad when it happens on `release` https://github.com/digicatapult/dtdl-visualisation-tool/actions/runs/13546499633/job/37859316900

- Concurrency should reduce the number of times we're unnecessarily running the test workflow. See annotations on this run saying it was cancelled by a new commit on the branch https://github.com/digicatapult/dtdl-visualisation-tool/actions/runs/13550042788/job/37871183946

- Added a shared group across all branches for the e2e job, so that when it runs on `release`, that can take priority over all other runs.


## Describe alternatives you've considered

Could configure the GitHub login e2e test to only run on one browser type e.g. `chromium` instead of all 3. This would reduce the number of times the test user is being logged into and make it less likely we hit the rate limit.
