### PR TITLE
Bug - Move octokit token to cookies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.33",
+      "version": "0.4.34",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.80",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {

--- a/public/scripts/callbacks.js
+++ b/public/scripts/callbacks.js
@@ -25,7 +25,7 @@ htmx.on('htmx:load', (e) => {
   if (e?.detail.elt.baseURI.includes('github/picker')) {
     document.getElementById('github-modal').showModal()
 
-    // Update the browser history to hide GitHub callback parameters
+    // Update the browser history so modal only opens once
     window.history.replaceState({}, '', `/open`)
   }
 })

--- a/public/scripts/callbacks.js
+++ b/public/scripts/callbacks.js
@@ -24,10 +24,9 @@ globalThis.getOwnerRepoFromInput = (event) => {
 htmx.on('htmx:load', (e) => {
   if (e?.detail.elt.baseURI.includes('github/picker')) {
     document.getElementById('github-modal').showModal()
-    const sessionId = document.getElementById('sessionId').value
 
     // Update the browser history to hide GitHub callback parameters
-    window.history.replaceState({}, '', `/open?sessionId=${sessionId}`)
+    window.history.replaceState({}, '', `/open`)
   }
 })
 

--- a/src/lib/server/controllers/__tests__/github.test.ts
+++ b/src/lib/server/controllers/__tests__/github.test.ts
@@ -112,7 +112,7 @@ describe('GithubController', async () => {
     mockCache
   )
 
-  const assertNoTokenRedirect = async <T>(controllerFn: () => Promise<T>) => {
+  const assertRedirectOnNoToken = async <T>(controllerFn: () => Promise<T>, hxRidirect: boolean = true) => {
     const setHeaderSpy = sinon.spy(controller, 'setHeader')
     const setStatusSpy = sinon.spy(controller, 'setStatus')
 
@@ -120,7 +120,7 @@ describe('GithubController', async () => {
 
     const redirect = encodeURIComponent(`${env.get('GH_REDIRECT_ORIGIN')}/github/callback?returnUrl=/github/picker`)
 
-    expect(setHeaderSpy.firstCall.args[0]).to.equal('HX-Redirect')
+    expect(setHeaderSpy.firstCall.args[0]).to.equal(hxRidirect ? 'HX-Redirect' : 'Location')
     expect(setHeaderSpy.firstCall.args[1]).to.equal(
       `https://github.com/login/oauth/authorize?client_id=${env.get('GH_CLIENT_ID')}&redirect_uri=${redirect}`
     )
@@ -144,12 +144,12 @@ describe('GithubController', async () => {
     })
 
     it('should redirect if octokit token NOT present in cookies', async () => {
-      await assertNoTokenRedirect(() => controller.picker(mockReqWithCookie({})))
+      await assertRedirectOnNoToken(() => controller.picker(mockReqWithCookie({})), false)
     })
   })
 
   describe('/callback', () => {
-    it('should redirect to return url from session', async () => {
+    it('should set cookie and redirect to return url from session', async () => {
       const setHeaderSpy = sinon.spy(controller, 'setHeader')
       const req = mockReqWithCookie({})
       const returnUrl = 'return.url'
@@ -186,7 +186,7 @@ describe('GithubController', async () => {
     })
 
     it('should redirect if octokit token NOT present in cookies', async () => {
-      await assertNoTokenRedirect(() => controller.repos(page, mockReqWithCookie({})))
+      await assertRedirectOnNoToken(() => controller.repos(page, mockReqWithCookie({})))
     })
   })
 
@@ -213,7 +213,7 @@ describe('GithubController', async () => {
     })
 
     it('should redirect if octokit token NOT present in cookies', async () => {
-      await assertNoTokenRedirect(() => controller.branches(mockOwner, mockRepo, page, mockReqWithCookie({})))
+      await assertRedirectOnNoToken(() => controller.branches(mockOwner, mockRepo, page, mockReqWithCookie({})))
     })
   })
 
@@ -264,7 +264,7 @@ describe('GithubController', async () => {
     })
 
     it('should redirect if octokit token NOT present in cookies', async () => {
-      await assertNoTokenRedirect(() =>
+      await assertRedirectOnNoToken(() =>
         controller.contents(mockOwner, mockRepo, mockDirPath, mockBranch, mockReqWithCookie({}))
       )
     })

--- a/src/lib/server/controllers/__tests__/helpers.test.ts
+++ b/src/lib/server/controllers/__tests__/helpers.test.ts
@@ -2,6 +2,7 @@ import * as chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { afterEach, describe, it } from 'mocha'
 import sinon from 'sinon'
+import { modelHistoryCookie } from '../../models/cookieNames.js'
 import { recentFilesFromCookies } from '../helpers.js'
 import { mockDb, mockLogger, previewDtdlId, simpleDtdlId } from './helpers.js'
 
@@ -26,7 +27,7 @@ describe('recentFilesFromCookies', () => {
 
   it('should return recent files for valid cookie history', async () => {
     const cookies = {
-      DTDL_MODEL_HISTORY: [{ id: previewDtdlId, timestamp: validTimestamp.getTime() }],
+      [modelHistoryCookie]: [{ id: previewDtdlId, timestamp: validTimestamp.getTime() }],
     }
 
     const result = await recentFilesFromCookies(cookies, mockDb, mockLogger)
@@ -43,7 +44,7 @@ describe('recentFilesFromCookies', () => {
 
   it('should filter out invalid models from cookie history', async () => {
     const cookies = {
-      DTDL_MODEL_HISTORY: [
+      [modelHistoryCookie]: [
         { id: previewDtdlId, timestamp: validTimestamp.getTime() },
         { id: invalidModelId, timestamp: validTimestamp.getTime() },
       ],
@@ -71,7 +72,7 @@ describe('recentFilesFromCookies', () => {
     previewModelTimestamp.setHours(15, 0, 0, 0)
 
     const cookies = {
-      DTDL_MODEL_HISTORY: [
+      [modelHistoryCookie]: [
         { id: previewDtdlId, timestamp: previewModelTimestamp.getTime() },
         { id: simpleDtdlId, timestamp: simpleModelTimestamp },
       ],

--- a/src/lib/server/controllers/__tests__/helpers.ts
+++ b/src/lib/server/controllers/__tests__/helpers.ts
@@ -3,7 +3,7 @@ import { Readable } from 'node:stream'
 import { pino } from 'pino'
 
 import { EntityType } from '@digicatapult/dtdl-parser'
-import sinon, { SinonStub } from 'sinon'
+import sinon from 'sinon'
 import Database from '../../../db/index.js'
 import { ListItem } from '../../models/github.js'
 import { Layout } from '../../models/mermaidLayouts.js'
@@ -42,11 +42,9 @@ export const templateMock = {
     `svgControls_${generatedOutput}_svgControls`,
 } as unknown as MermaidTemplates
 export const openOntologyMock = {
-  OpenOntologyRoot: ({ sessionId, populateListLink }: { sessionId: UUID; populateListLink?: string }) =>
-    `root_${sessionId}_${populateListLink}_root`,
+  OpenOntologyRoot: ({ populateListLink }: { populateListLink?: string }) => `root_${populateListLink}_root`,
   mainView: (): JSX.Element => `mainView_SomethingHere_mainView`,
-  getMenu: ({ showContent, sessionId }: { showContent: boolean; sessionId: UUID }) =>
-    `uploadMethod_${showContent}_${sessionId}_uploadMethod`,
+  getMenu: ({ showContent }: { showContent: boolean }) => `uploadMethod_${showContent}_uploadMethod`,
   uploadZip: () => `uploadZip_Zip_uploadZip`,
   uploadGithub: (): JSX.Element => `uploadGithub_Github_uploadGithub`,
   githubListItems: ({
@@ -137,6 +135,6 @@ export const mockReqWithCookie = (cookie: Record<string, unknown>) => {
 
 export const mockRes = () => {
   return {
-    cookie: sinon.stub() as SinonStub,
+    cookie: sinon.spy(),
   } as unknown as express.Response
 }

--- a/src/lib/server/controllers/__tests__/sessionFixtures.ts
+++ b/src/lib/server/controllers/__tests__/sessionFixtures.ts
@@ -30,6 +30,4 @@ export const sessionMap = {
   [validSessionExpanded9XId]: { ...validSession, expandedIds: ['9', '10'] },
   [validSessionSomeSearchId]: { ...validSession, search: 'someSearch' },
   [validSessionSomeOtherSearchId]: { ...validSession, search: 'someOtherSearch' },
-  [validSessionOctokitId]: { ...validSession, octokitToken: 'octokit' },
-  [validSessionReturnUrlId]: { ...validSession, returnUrl: 'return.url' },
 }

--- a/src/lib/server/controllers/upload.ts
+++ b/src/lib/server/controllers/upload.ts
@@ -3,12 +3,11 @@ import os from 'node:os'
 
 import express from 'express'
 import { join } from 'node:path'
-import { FormField, Get, Post, Produces, Query, Request, Route, SuccessResponse, UploadedFile } from 'tsoa'
+import { Get, Post, Produces, Query, Request, Route, SuccessResponse, UploadedFile } from 'tsoa'
 import { inject, injectable } from 'tsyringe'
 import unzipper from 'unzipper'
 import Database from '../../db/index.js'
-import { SessionError, UploadError } from '../errors.js'
-import { type UUID } from '../models/strings.js'
+import { UploadError } from '../errors.js'
 import { parseAndInsertDtdl } from '../utils/dtdl/parse.js'
 import OpenOntologyTemplates from '../views/components/openOntology.js'
 import { HTML, HTMLController } from './HTMLController.js'
@@ -35,25 +34,22 @@ export class OpenOntologyController extends HTMLController {
 
   @SuccessResponse(200)
   @Get('/')
-  public async open(@Request() req: express.Request, @Query() sessionId?: UUID): Promise<HTML> {
-    if (!sessionId) {
-      throw new SessionError('No session ID provided')
-    }
+  public async open(@Request() req: express.Request): Promise<HTML> {
     this.setHeader('HX-Push-Url', `/open`)
 
     const recentFiles = await recentFilesFromCookies(req.signedCookies, this.db, this.logger)
-    return this.html(this.openOntologyTemplates.OpenOntologyRoot({ sessionId, recentFiles }))
+    return this.html(this.openOntologyTemplates.OpenOntologyRoot({ recentFiles }))
   }
 
   @SuccessResponse(200)
   @Get('/menu')
-  public async getMenu(@Query() showContent: boolean, @Query() sessionId: UUID): Promise<HTML> {
-    return this.html(this.openOntologyTemplates.getMenu({ showContent, sessionId }))
+  public async getMenu(@Query() showContent: boolean): Promise<HTML> {
+    return this.html(this.openOntologyTemplates.getMenu({ showContent }))
   }
 
   @SuccessResponse(302, 'File uploaded successfully')
   @Post('/')
-  public async uploadZip(@UploadedFile('file') file: Express.Multer.File, @FormField() sessionId: UUID): Promise<void> {
+  public async uploadZip(@UploadedFile('file') file: Express.Multer.File): Promise<void> {
     if (file.mimetype !== 'application/zip') {
       throw new UploadError('File must be a .zip')
     }
@@ -67,7 +63,7 @@ export class OpenOntologyController extends HTMLController {
 
     const id = await parseAndInsertDtdl(unzippedPath, file.originalname, this.db, this.generator, false, this.cache)
 
-    this.setHeader('HX-Redirect', `/ontology/${id}/view?sessionId=${sessionId}`)
+    this.setHeader('HX-Redirect', `/ontology/${id}/view`)
     return
   }
 

--- a/src/lib/server/models/cookieNames.ts
+++ b/src/lib/server/models/cookieNames.ts
@@ -1,1 +1,2 @@
 export const modelHistoryCookie = 'DTDL_MODEL_HISTORY'
+export const octokitTokenCookie = 'OCTOKIT_TOKEN'

--- a/src/lib/server/utils/sessions.ts
+++ b/src/lib/server/utils/sessions.ts
@@ -10,7 +10,6 @@ export type Session = {
   search?: string
   highlightNodeId?: string
   expandedIds: string[]
-  octokitToken?: string
   returnUrl?: string
 }
 

--- a/src/lib/server/views/components/mermaid.tsx
+++ b/src/lib/server/views/components/mermaid.tsx
@@ -8,7 +8,6 @@ import { DiagramType, diagramTypes } from '../../models/mermaidDiagrams.js'
 import { Layout, layoutEntries } from '../../models/mermaidLayouts.js'
 import { DtdlId, UUID } from '../../models/strings.js'
 import { getDisplayName, isInterface, isRelationship } from '../../utils/dtdl/extract.js'
-import { safeUrl } from '../../utils/url.js'
 import { AccordionSection, Page } from '../common.js'
 
 const commonUpdateAttrs = {
@@ -53,7 +52,7 @@ export default class MermaidTemplates {
           svgWidth={svgWidth}
           svgHeight={svgHeight}
         />
-        <this.uploadForm sessionId={sessionId} />
+        <this.uploadForm />
       </section>
 
       <div id="mermaid-wrapper">
@@ -345,9 +344,9 @@ export default class MermaidTemplates {
     )
   }
 
-  private uploadForm = ({ sessionId }: { sessionId: UUID }) => {
+  private uploadForm = () => {
     return (
-      <a id="open-button" href={safeUrl(`/open`, { sessionId })} class="button">
+      <a id="open-button" href={`/open`} class="button">
         Open Ontology
       </a>
     )

--- a/src/lib/server/views/components/openOntology.tsx
+++ b/src/lib/server/views/components/openOntology.tsx
@@ -4,8 +4,6 @@ import { escapeHtml } from '@kitajs/html'
 import { singleton } from 'tsyringe'
 import { ListItem } from '../../models/github.js'
 import { RecentFile } from '../../models/openTypes.js'
-import { UUID } from '../../models/strings.js'
-import { safeUrl } from '../../utils/url.js'
 import { Page } from '../common.js'
 
 @singleton()
@@ -13,18 +11,15 @@ export default class OpenOntologyTemplates {
   constructor() {}
 
   public OpenOntologyRoot = ({
-    sessionId,
     populateListLink,
     recentFiles,
   }: {
-    sessionId: UUID
     populateListLink?: string
     recentFiles: RecentFile[]
   }) => {
     const showGithubModal = populateListLink !== undefined
     return (
       <Page title="UKDTC">
-        <input id="sessionId" name="sessionId" type="hidden" value={escapeHtml(sessionId)} />
         <section id="upload-toolbar">
           <a href="/">
             <h2>UKDTC</h2>
@@ -32,8 +27,8 @@ export default class OpenOntologyTemplates {
         </section>
         <div id="main-view">
           <h1>Open Ontology</h1>
-          <this.getMenu showContent={false} sessionId={sessionId} />
-          <this.recentFiles recentFiles={recentFiles} sessionId={sessionId} />
+          <this.getMenu showContent={false} />
+          <this.recentFiles recentFiles={recentFiles} />
           {showGithubModal && <this.githubModal populateListLink={populateListLink} />}
           <div id="spinner-wrapper">
             <div id="spinner" class="spinner" />
@@ -43,7 +38,7 @@ export default class OpenOntologyTemplates {
     )
   }
 
-  public getMenu = ({ showContent, sessionId }: { showContent: boolean; sessionId: UUID }) => {
+  public getMenu = ({ showContent }: { showContent: boolean }) => {
     return (
       <section id="upload-method">
         <label
@@ -51,7 +46,6 @@ export default class OpenOntologyTemplates {
           hx-swap="outerHTML transition:true"
           hx-target="#upload-method"
           hx-trigger="click"
-          hx-include="#sessionId"
           hx-get={`/open/menu?showContent=${!showContent}`}
         >
           Upload New File
@@ -59,7 +53,7 @@ export default class OpenOntologyTemplates {
         </label>
         <div id="upload-options" class={showContent ? 'show-content' : ''}>
           <this.uploadZip />
-          <this.uploadGithub sessionId={sessionId} />
+          <this.uploadGithub />
         </div>
       </section>
     )
@@ -75,19 +69,12 @@ export default class OpenOntologyTemplates {
               placeholder="Enter public GitHub repo {org}/{repo} e.g. 'digicatapult/dtdl-visualisation-tool'"
               hx-get="/github/branches?page=1"
               hx-trigger="keyup[event.key=='Enter']"
-              hx-include="#sessionId"
               hx-vals="js:{ owner: globalThis.getOwnerRepoFromInput(event).owner, repo: globalThis.getOwnerRepoFromInput(event).repo }"
               hx-target=".github-list"
             />
           </div>
           <div id="spin" class="spinner" />
-          <ul
-            class="github-list"
-            hx-indicator="#spin"
-            hx-get={populateListLink}
-            hx-trigger="load"
-            hx-include="#sessionId"
-          ></ul>
+          <ul class="github-list" hx-indicator="#spin" hx-get={populateListLink} hx-trigger="load"></ul>
           <this.selectFolder />
         </div>
         <form method="dialog">
@@ -101,7 +88,6 @@ export default class OpenOntologyTemplates {
     <button
       id="select-folder"
       hx-trigger="click"
-      hx-include="#sessionId"
       hx-get={link}
       hx-swap-oob={swapOutOfBand ? 'true' : undefined}
       hx-swap="outerHTML"
@@ -128,7 +114,6 @@ export default class OpenOntologyTemplates {
       'hx-get': nextPageLink,
       'hx-trigger': 'intersect once',
       'hx-swap': 'afterend',
-      'hx-include': '#sessionId',
       style: 'height: 1px; overflow: hidden',
     }
 
@@ -162,7 +147,6 @@ export default class OpenOntologyTemplates {
         hx-post="/open/"
         hx-encoding="multipart/form-data"
         hx-trigger="change from:#zip"
-        hx-include="#sessionId"
       >
         <label for="zip" class="upload-option">
           <img src="/public/images/zip-folder.svg" alt="zip-folder" />
@@ -172,16 +156,16 @@ export default class OpenOntologyTemplates {
       </form>
     )
   }
-  private uploadGithub = ({ sessionId }: { sessionId: UUID }) => {
+  private uploadGithub = () => {
     return (
-      <a class="upload-option button" href={`/github/picker?sessionId=${sessionId}`}>
+      <a class="upload-option button" hx-get="/github/picker" hx-trigger="click">
         <img src="/public/images/github-mark.svg" alt="github" />
         <span>GitHub</span>
       </a>
     )
   }
 
-  public recentFiles = ({ recentFiles, sessionId }: { recentFiles: RecentFile[]; sessionId: UUID }) => {
+  public recentFiles = ({ recentFiles }: { recentFiles: RecentFile[] }) => {
     return (
       <>
         <h4>Recent Files</h4>
@@ -189,7 +173,7 @@ export default class OpenOntologyTemplates {
           {recentFiles.map((recentFile, index) => {
             const preview: JSX.Element = recentFile.preview
             return (
-              <a href={safeUrl(`/ontology/${recentFile.dtdlModelId}/view`, { sessionId })}>
+              <a href={`/ontology/${recentFile.dtdlModelId}/view`}>
                 <div class="file-card" role="button" tabindex={`${index + 1}`}>
                   <div class="file-preview">{preview}</div>
                   <div class="file-details">

--- a/src/lib/server/views/components/openOntology.tsx
+++ b/src/lib/server/views/components/openOntology.tsx
@@ -158,7 +158,7 @@ export default class OpenOntologyTemplates {
   }
   private uploadGithub = () => {
     return (
-      <a class="upload-option button" hx-get="/github/picker" hx-trigger="click">
+      <a class="upload-option button" href={`/github/picker`}>
         <img src="/public/images/github-mark.svg" alt="github" />
         <span>GitHub</span>
       </a>


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-116

## High level description

Move octokit out of sessions and into local cookies.  This means if a user gives another user their session ID, they won't leak their octokit token.
Remove passing around of sessionId for the upload routes. A new session is always started when viewing an ontology for the first time.

## Operational impact

None