### PR TITLE
Global setup GitHub login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ obj
 /test-results/
 /playwright-report/
 /playwright/.cache/
+storage-state.json
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ obj
 /test-results/
 /playwright-report/
 /playwright/.cache/
-storage-state.json
 .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.34",
+      "version": "0.4.35",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.80",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig, devices } from '@playwright/test'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 export default defineConfig({
   globalSetup: './test/globalSetup.ts',
@@ -22,7 +24,7 @@ export default defineConfig({
     trace: 'on-first-retry',
     baseURL: 'http://127.0.0.1:3000',
     headless: !!process.env.CI,
-    storageState: 'storage-state.json',
+    storageState: join(tmpdir(), 'storage-state.json'),
   },
   expect: {
     timeout: 10 * 1000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     trace: 'on-first-retry',
     baseURL: 'http://127.0.0.1:3000',
     headless: !!process.env.CI,
+    storageState: 'storage-state.json',
   },
   expect: {
     timeout: 10 * 1000,

--- a/test/e2e/githubOAuth.spec.ts
+++ b/test/e2e/githubOAuth.spec.ts
@@ -4,8 +4,6 @@ import { waitForSuccessResponse, waitForUpdateLayout } from './helpers/waitForHe
 
 test.describe('Upload ontology from GitHub via OAuth', () => {
   test('Success path for uploading ontology from private Github repo + from public Github repo', async ({ page }) => {
-    test.setTimeout(120000)
-
     // Set viewport and navigate to the page, smaller viewports hide UI elements
     await page.setViewportSize({ width: 1920, height: 1080 })
     await waitForUpdateLayout(page, () => page.goto('./'))

--- a/test/e2e/githubOAuth.spec.ts
+++ b/test/e2e/githubOAuth.spec.ts
@@ -1,40 +1,10 @@
 import { expect, test } from '@playwright/test'
-import { TOTP } from 'otpauth'
 
-import { octokitTokenCookie } from '../../src/lib/server/models/cookieNames'
 import { waitForSuccessResponse, waitForUpdateLayout } from './helpers/waitForHelpers'
 
-const ghTestUser = process.env.GH_TEST_USER
-const ghTestPassword = process.env.GH_TEST_PASSWORD
-const gh2faSecret = process.env.GH_TEST_2FA_SECRET
-
-if (!ghTestUser || !ghTestPassword || !gh2faSecret) throw new Error('Test GitHub user credentials required')
-
-const totp = new TOTP({
-  issuer: 'GitHub',
-  label: 'test',
-  algorithm: 'SHA1',
-  digits: 6,
-  period: 30,
-  secret: gh2faSecret,
-})
-
 test.describe('Upload ontology from GitHub via OAuth', () => {
-  test.only('Success path for uploading ontology from private Github repo + from public Github repo', async ({
-    context,
-  }) => {
+  test('Success path for uploading ontology from private Github repo + from public Github repo', async ({ page }) => {
     test.setTimeout(120000)
-
-    await context.addCookies([
-      {
-        name: octokitTokenCookie,
-        value: process.env.OCTOKIT_TOKEN!,
-        path: '/',
-        domain: '127.0.0.1',
-        secure: false,
-      },
-    ])
-    const page = await context.newPage()
 
     // Set viewport and navigate to the page, smaller viewports hide UI elements
     await page.setViewportSize({ width: 1920, height: 1080 })
@@ -42,7 +12,7 @@ test.describe('Upload ontology from GitHub via OAuth', () => {
 
     await waitForSuccessResponse(page, () => page.locator('#open-button').click(), '/open')
     await waitForSuccessResponse(page, () => page.locator('#main-view').getByText('Upload New File').click(), '/menu')
-    await waitForSuccessResponse(page, () => page.locator('#main-view').getByText('GitHub').click(), 'github.com/login')
+    await waitForSuccessResponse(page, () => page.locator('#main-view').getByText('GitHub').click(), '/repos')
 
     // click first of test users repos
     await expect(page.locator('.github-list li').first()).toBeVisible()

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -1,9 +1,93 @@
+import { FullConfig, Page, chromium } from '@playwright/test'
+import { TOTP } from 'otpauth'
 import 'reflect-metadata'
+import { octokitTokenCookie } from '../src/lib/server/models/cookieNames.js'
+import { waitForSuccessResponse, waitForUpdateLayout } from './e2e/helpers/waitForHelpers.js'
 import { bringUpDatabaseContainer, bringUpVisualisationContainer } from './testcontainers/testContainersSetup.js'
 
-async function globalSetup() {
+async function globalSetup(config: FullConfig) {
   await bringUpDatabaseContainer()
   await bringUpVisualisationContainer()
+  await getGithubToken(config)
+}
+
+const ghTestUser = process.env.GH_TEST_USER
+const ghTestPassword = process.env.GH_TEST_PASSWORD
+const gh2faSecret = process.env.GH_TEST_2FA_SECRET
+
+const totp = new TOTP({
+  issuer: 'GitHub',
+  label: 'test',
+  algorithm: 'SHA1',
+  digits: 6,
+  period: 30,
+  secret: gh2faSecret,
+})
+
+const attempt2fa = async (page: Page) => {
+  await page.fill('#app_totp', totp.generate())
+  await page.waitForTimeout(2000)
+
+  // Check if 2fa code already used
+  if (await page.locator('.js-flash-alert').isVisible()) {
+    const remaining = totp.period - (Math.floor(Date.now() / 1000) % totp.period)
+    await page.waitForTimeout(remaining * 1000)
+    return attempt2fa(page)
+  } else {
+    return
+  }
+}
+
+async function getGithubToken(config: FullConfig) {
+  if (!ghTestUser || !ghTestPassword || !gh2faSecret) {
+    throw new Error('Test GitHub user credentials required')
+  }
+  const { baseURL } = config.projects[0].use
+
+  const browser = await chromium.launch()
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  // Set viewport and navigate to your app
+  await page.setViewportSize({ width: 1920, height: 1080 })
+  await waitForUpdateLayout(page, () => page.goto(baseURL!))
+
+  await waitForSuccessResponse(page, () => page.locator('#open-button').click(), '/open')
+  await waitForSuccessResponse(page, () => page.locator('#main-view').getByText('Upload New File').click(), '/menu')
+  await waitForSuccessResponse(page, () => page.locator('#main-view').getByText('GitHub').click(), 'github.com/login')
+
+  // Wait for GitHub login form
+  await page.waitForSelector('#login')
+
+  // Fill in the credentials and sign in
+  await page.fill('#login_field', ghTestUser)
+  await page.fill('#password', ghTestPassword)
+  await waitForSuccessResponse(page, () => page.click('input[name="commit"]'), 'github.com/sessions/two-factor/app')
+  await page.waitForSelector('#app_totp')
+
+  await attempt2fa(page)
+
+  // wait for redirection
+  await page.waitForTimeout(5000)
+
+  // Sometimes GitHub requests reauthorisation
+  if (!page.url().includes('/open')) {
+    if (await page.getByText('too many codes').isVisible()) {
+      throw new Error('GitHub login of test user requested too many times. Try again in a few minutes')
+    }
+    await waitForSuccessResponse(page, () => page.locator('button:has-text("authorize")').click(), '/repos')
+  }
+
+  // Retrieve the token from cookies
+  const cookies = await context.cookies()
+  const tokenCookie = cookies.find((cookie) => cookie.name === octokitTokenCookie)
+  if (!tokenCookie) {
+    throw new Error(`${octokitTokenCookie} not found in cookies after login`)
+  }
+
+  process.env.OCTOKIT_TOKEN = tokenCookie.value
+
+  await browser.close()
 }
 
 export default globalSetup

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -42,7 +42,7 @@ async function getGithubToken(config: FullConfig) {
   if (!ghTestUser || !ghTestPassword || !gh2faSecret) {
     throw new Error('Test GitHub user credentials required')
   }
-  const { baseURL } = config.projects[0].use
+  const { baseURL, storageState } = config.projects[0].use
 
   const browser = await chromium.launch()
   const context = await browser.newContext()
@@ -86,6 +86,7 @@ async function getGithubToken(config: FullConfig) {
   }
 
   process.env.OCTOKIT_TOKEN = tokenCookie.value
+  await page.context().storageState({ path: storageState as string })
 
   await browser.close()
 }

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -1,7 +1,6 @@
 import { FullConfig, Page, chromium } from '@playwright/test'
 import { TOTP } from 'otpauth'
 import 'reflect-metadata'
-import { octokitTokenCookie } from '../src/lib/server/models/cookieNames.js'
 import { waitForSuccessResponse, waitForUpdateLayout } from './e2e/helpers/waitForHelpers.js'
 import { bringUpDatabaseContainer, bringUpVisualisationContainer } from './testcontainers/testContainersSetup.js'
 
@@ -78,14 +77,7 @@ async function getGithubToken(config: FullConfig) {
     await waitForSuccessResponse(page, () => page.locator('button:has-text("authorize")').click(), '/repos')
   }
 
-  // Retrieve the token from cookies
-  const cookies = await context.cookies()
-  const tokenCookie = cookies.find((cookie) => cookie.name === octokitTokenCookie)
-  if (!tokenCookie) {
-    throw new Error(`${octokitTokenCookie} not found in cookies after login`)
-  }
-
-  process.env.OCTOKIT_TOKEN = tokenCookie.value
+  // Store current state (cookies) for future tests
   await page.context().storageState({ path: storageState as string })
 
   await browser.close()


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-102

## High level description

Use global playwright setup to log in to GitHub (adds octokit token to cookies) then use `storageState` so the current state is starting state for all future tests. Means only one log in to GitHub per test run
