### PR TITLE
takes full URL as well as owner/repo combo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.41",
+  "version": "0.4.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.41",
+  "version": "0.4.42",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {

--- a/public/scripts/callbacks.js
+++ b/public/scripts/callbacks.js
@@ -22,10 +22,13 @@ globalThis.toggleEditSwitch = (event) => {
 }
 
 globalThis.getOwnerRepoFromInput = (event) => {
-  const [owner, repo] = event.target.value.split('/')
-  return {
-    owner: owner || undefined,
-    repo: repo || undefined,
+  const input = event.target.value.trim()
+  try {
+    const [, owner, repo] = new URL(input).pathname.split('/')
+    return { owner, repo }
+  } catch {
+    const [owner, repo] = input.split('/')
+    return { owner, repo }
   }
 }
 


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Feature

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-119

## High level description

on github picker, user can enter full repo link as well as owner/repo string

## Detailed description

Using a try catch block while parsing the user input into `new URL(input)`. If it is unable to parse as a URL it will attempt to get the owner/repo using the original split
