### PR TITLE
Remove layout select from UI and app routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.44",
+      "version": "0.4.45",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.84",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "description": "CLI tool for dtdl visualisation",
   "main": "src/index.js",
   "bin": {

--- a/src/lib/server/controllers/__tests__/helpers.ts
+++ b/src/lib/server/controllers/__tests__/helpers.ts
@@ -8,7 +8,6 @@ import Database from '../../../db/index.js'
 import { ModelDb } from '../../../db/modelDb.js'
 import { InternalError } from '../../errors.js'
 import { ListItem } from '../../models/github.js'
-import { Layout } from '../../models/mermaidLayouts.js'
 import { type UUID } from '../../models/strings.js'
 import { allInterfaceFilter } from '../../utils/dtdl/extract.js'
 import { FuseSearch } from '../../utils/fuseSearch.js'
@@ -41,11 +40,11 @@ const mockModelTable = {
 }
 
 export const templateMock = {
-  MermaidRoot: ({ search, layout }: { search: string; layout: string }) => `root_${layout}_${search}_root`,
+  MermaidRoot: ({ search }: { search: string }) => `root_${search}_root`,
   mermaidTarget: ({ generatedOutput, target }: { generatedOutput?: JSX.Element; target: string }): JSX.Element =>
     `mermaidTarget_${generatedOutput}_${target}_mermaidTarget`,
-  searchPanel: ({ search, layout, swapOutOfBand }: { search?: string; layout: Layout; swapOutOfBand?: boolean }) =>
-    `searchPanel_${search}_${layout}_${swapOutOfBand || false}_searchPanel`,
+  searchPanel: ({ search, swapOutOfBand }: { search?: string; swapOutOfBand?: boolean }) =>
+    `searchPanel_${search}_${swapOutOfBand || false}_searchPanel`,
   navigationPanel: ({ swapOutOfBand, content }: { swapOutOfBand?: boolean; content?: string }) =>
     `navigationPanel_${swapOutOfBand || false}_${content || ''}_navigationPanel`,
   svgControls: ({ generatedOutput }: { generatedOutput?: JSX.Element }): JSX.Element =>

--- a/src/lib/server/controllers/__tests__/root.test.ts
+++ b/src/lib/server/controllers/__tests__/root.test.ts
@@ -8,7 +8,6 @@ import { validSessionId } from './sessionFixtures.js'
 
 export const defaultParams: UpdateParams = {
   sessionId: validSessionId,
-  layout: 'dagre-d3',
   diagramType: 'flowchart',
   svgWidth: 300,
   svgHeight: 100,

--- a/src/lib/server/controllers/__tests__/sessionFixtures.ts
+++ b/src/lib/server/controllers/__tests__/sessionFixtures.ts
@@ -13,7 +13,7 @@ export const validSessionReturnUrlId = '6cfacf2a-5058-4c20-95da-a7dc7659ea60' as
 export const invalidSessionId = '00000000-0000-0000-0000-000000000000' as const
 
 export const validSession = {
-  layout: 'dagre-d3',
+  layout: 'elk',
   diagramType: 'flowchart',
   search: undefined,
   highlightNodeId: undefined,

--- a/src/lib/server/controllers/ontology/__tests__/index.test.ts
+++ b/src/lib/server/controllers/ontology/__tests__/index.test.ts
@@ -38,7 +38,6 @@ import { OntologyController } from '../index.js'
 
 export const defaultParams: UpdateParams = {
   sessionId: validSessionId,
-  layout: 'dagre-d3',
   diagramType: 'flowchart',
   svgWidth: 300,
   svgHeight: 100,
@@ -83,7 +82,7 @@ describe('OntologyController', async () => {
       const result = await controller
         .view(simpleDtdlId, { ...defaultParams }, req)
         .then((value) => (value ? toHTMLString(value) : ''))
-      expect(result).to.equal(`root_dagre-d3_undefined_root`)
+      expect(result).to.equal(`root_undefined_root`)
     })
 
     it('should set a cookie with model history', async () => {
@@ -111,7 +110,7 @@ describe('OntologyController', async () => {
       expect(result).to.equal(
         [
           `mermaidTarget_${generatedSVGFixture}_attr_mermaid-output_mermaidTarget`,
-          `searchPanel_undefined_dagre-d3_true_searchPanel`,
+          `searchPanel_undefined_true_searchPanel`,
           `navigationPanel_true__navigationPanel`,
           `svgControls_${generatedSVGFixture}_svgControls`,
         ].join('')
@@ -126,7 +125,7 @@ describe('OntologyController', async () => {
       expect(result).to.equal(
         [
           `mermaidTarget_${generatedSVGFixture}_attr_mermaid-output_mermaidTarget`,
-          `searchPanel_example 1_dagre-d3_true_searchPanel`,
+          `searchPanel_example 1_true_searchPanel`,
           `navigationPanel_true__navigationPanel`,
           `svgControls_${generatedSVGFixture}_svgControls`,
         ].join('')
@@ -135,7 +134,7 @@ describe('OntologyController', async () => {
 
     it('should render plain text content', async () => {
       const req = mockReq({})
-      mockCache.set(`diagramType=flowchart&dtdlId=${simpleDtdlId}&layout=dagre-d3`, {
+      mockCache.set(`diagramType=flowchart&dtdlId=${simpleDtdlId}&layout=elk`, {
         type: 'text',
         content: 'None',
       })
@@ -150,7 +149,7 @@ describe('OntologyController', async () => {
       expect(result).to.equal(
         [
           `mermaidTarget_None_mermaid-output_mermaidTarget`,
-          `searchPanel_undefined_dagre-d3_true_searchPanel`,
+          `searchPanel_undefined_true_searchPanel`,
           `navigationPanel_true__navigationPanel`,
           `svgControls__svgControls`,
         ].join('')
@@ -166,10 +165,7 @@ describe('OntologyController', async () => {
       await controller.updateLayout(req, simpleDtdlId, defaultParams).then(toHTMLString)
 
       expect(stub.callCount).to.equal(2)
-      expect(stub.firstCall.args).to.deep.equal([
-        'HX-Push-Url',
-        '/some/path?param1=x&param2=y&layout=dagre-d3&diagramType=flowchart',
-      ])
+      expect(stub.firstCall.args).to.deep.equal(['HX-Push-Url', '/some/path?param1=x&param2=y&diagramType=flowchart'])
       expect(stub.secondCall.args).to.deep.equal(['Content-Type', 'text/html'])
     })
 
@@ -177,14 +173,11 @@ describe('OntologyController', async () => {
       const stub = sinon.stub(controller, 'setHeader')
 
       const req = mockReq({
-        'hx-current-url': 'http://localhost:3000/some/path?param1=x&layout=y',
+        'hx-current-url': 'http://localhost:3000/some/path?param1=x',
       })
       await controller.updateLayout(req, simpleDtdlId, defaultParams).then(toHTMLString)
 
-      expect(stub.firstCall.args).to.deep.equal([
-        'HX-Push-Url',
-        '/some/path?param1=x&layout=dagre-d3&diagramType=flowchart',
-      ])
+      expect(stub.firstCall.args).to.deep.equal(['HX-Push-Url', '/some/path?param1=x&diagramType=flowchart'])
     })
 
     it('should not set HX-Push-Url header if hx-current-url is not passed', async () => {
@@ -213,7 +206,7 @@ describe('OntologyController', async () => {
       expect(stub.lastCall.args[1]).to.deep.equal({
         diagramType: 'flowchart',
         expandedIds: [],
-        layout: 'dagre-d3',
+        layout: 'elk',
         search: '"example 1"',
         highlightNodeId: 'dtmi:com:example;1',
       })
@@ -229,7 +222,7 @@ describe('OntologyController', async () => {
         .updateLayout(req, simpleDtdlId, { ...defaultParams, sessionId: validSessionExpanded11Id })
         .then(toHTMLString)
 
-      expect(stub.firstCall.args).to.deep.equal(['HX-Push-Url', '/some/path?layout=dagre-d3&diagramType=flowchart'])
+      expect(stub.firstCall.args).to.deep.equal(['HX-Push-Url', '/some/path?diagramType=flowchart'])
     })
 
     it('should append multiple expandedIds', async () => {
@@ -242,17 +235,14 @@ describe('OntologyController', async () => {
         .updateLayout(req, simpleDtdlId, { ...defaultParams, sessionId: validSessionExpanded12Id })
         .then(toHTMLString)
 
-      expect(stub.firstCall.args).to.deep.equal(['HX-Push-Url', '/some/path?layout=dagre-d3&diagramType=flowchart'])
+      expect(stub.firstCall.args).to.deep.equal(['HX-Push-Url', '/some/path?diagramType=flowchart'])
     })
 
     it('should cache generated output - keyed by params', async () => {
       const req = mockReq({})
       const generatorRunCount = generatorRunStub.callCount
       await controller.updateLayout(req, simpleDtdlId, defaultParams)
-      const fromCache = mockCache.get(
-        `diagramType=flowchart&dtdlId=${simpleDtdlId}&layout=dagre-d3`,
-        renderedDiagramParser
-      )
+      const fromCache = mockCache.get(`diagramType=flowchart&dtdlId=${simpleDtdlId}&layout=elk`, renderedDiagramParser)
       expect(fromCache).instanceOf(MermaidSvgRender)
       expect(fromCache?.renderToString()).to.deep.equal(generatedSVGFixture)
 
@@ -267,10 +257,7 @@ describe('OntologyController', async () => {
 
       expect(mockCache.size()).to.equal(1)
 
-      const fromCache = mockCache.get(
-        `diagramType=flowchart&dtdlId=${simpleDtdlId}&layout=dagre-d3`,
-        renderedDiagramParser
-      )
+      const fromCache = mockCache.get(`diagramType=flowchart&dtdlId=${simpleDtdlId}&layout=elk`, renderedDiagramParser)
       expect(fromCache).instanceOf(MermaidSvgRender)
       expect(fromCache?.renderToString()).to.deep.equal(generatedSVGFixture)
     })
@@ -379,7 +366,7 @@ describe('OntologyController', async () => {
       expect(result).to.equal(
         [
           `mermaidTarget_${generatedSVGFixture}_attr_animate_mermaid-output_mermaidTarget`,
-          `searchPanel_example_dagre-d3_true_searchPanel`,
+          `searchPanel_example_true_searchPanel`,
           `navigationPanel_true__navigationPanel`,
           `svgControls_${generatedSVGFixture}_svgControls`,
         ].join('')
@@ -400,7 +387,7 @@ describe('OntologyController', async () => {
       expect(result).to.equal(
         [
           `mermaidTarget_${generatedSVGFixture}_attr_mermaid-output_mermaidTarget`,
-          `searchPanel_example_dagre-d3_true_searchPanel`,
+          `searchPanel_example_true_searchPanel`,
           `navigationPanel_true__navigationPanel`,
           `svgControls_${generatedSVGFixture}_svgControls`,
         ].join('')
@@ -423,7 +410,7 @@ describe('OntologyController', async () => {
       expect(result).to.equal(
         [
           `mermaidTarget_${generatedSVGFixture}_attr_mermaid-output_mermaidTarget`,
-          `searchPanel_example_dagre-d3_true_searchPanel`,
+          `searchPanel_example_true_searchPanel`,
           `navigationPanel_true__navigationPanel`,
           `svgControls_${generatedSVGFixture}_svgControls`,
         ].join('')
@@ -432,7 +419,7 @@ describe('OntologyController', async () => {
 
     it('should not animate if only highlighted node changes', async () => {
       const req = mockReq({})
-      mockCache.set('diagramType=flowchart&layout=dagre-d3', new MermaidSvgRender(Buffer.from(generatedSVGFixture)))
+      mockCache.set('diagramType=flowchart', new MermaidSvgRender(Buffer.from(generatedSVGFixture)))
 
       const result = await controller
         .updateLayout(req, simpleDtdlId, {
@@ -445,7 +432,7 @@ describe('OntologyController', async () => {
       expect(result).to.equal(
         [
           `mermaidTarget_${generatedSVGFixture}_attr_mermaid-output_mermaidTarget`,
-          `searchPanel_undefined_dagre-d3_true_searchPanel`,
+          `searchPanel_undefined_true_searchPanel`,
           `navigationPanel_true__navigationPanel`,
           `svgControls_${generatedSVGFixture}_svgControls`,
         ].join('')
@@ -454,7 +441,7 @@ describe('OntologyController', async () => {
 
     it('should not animate if old output was plain text', async () => {
       const req = mockReq({})
-      mockCache.set('diagramType=flowchart&layout=dagre-d3', new PlainTextRender('None'))
+      mockCache.set('diagramType=flowchart', new PlainTextRender('None'))
 
       const result = await controller
         .updateLayout(req, simpleDtdlId, {
@@ -467,7 +454,7 @@ describe('OntologyController', async () => {
       expect(result).to.equal(
         [
           `mermaidTarget_${generatedSVGFixture}_attr_mermaid-output_mermaidTarget`,
-          `searchPanel_example_dagre-d3_true_searchPanel`,
+          `searchPanel_example_true_searchPanel`,
           `navigationPanel_true__navigationPanel`,
           `svgControls_${generatedSVGFixture}_svgControls`,
         ].join('')

--- a/src/lib/server/controllers/ontology/index.ts
+++ b/src/lib/server/controllers/ontology/index.ts
@@ -76,7 +76,6 @@ export class OntologyController extends HTMLController {
 
     this.logger.debug(`model ${dtdlModelId} requested with search: %o`, {
       search: params.search,
-      layout: params.layout,
     })
 
     let sessionId = params.sessionId
@@ -84,7 +83,7 @@ export class OntologyController extends HTMLController {
     if (!sessionId || !this.sessionStore.get(sessionId)) {
       sessionId = randomUUID()
       const session = {
-        layout: params.layout,
+        layout: 'elk' as const,
         diagramType: params.diagramType,
         search: params.search,
         highlightNodeId: params.highlightNodeId,
@@ -113,7 +112,6 @@ export class OntologyController extends HTMLController {
 
     return this.html(
       this.templates.MermaidRoot({
-        layout: params.layout,
         search: params.search,
         sessionId,
         diagramType: params.diagramType,
@@ -129,7 +127,7 @@ export class OntologyController extends HTMLController {
     @Path() dtdlModelId: UUID,
     @Queries() params: UpdateParams
   ): Promise<HTML> {
-    this.logger.debug('search: %o', { search: params.search, layout: params.layout })
+    this.logger.debug('search: %o', { search: params.search })
 
     // pull out the stored session. If this is invalid the request is invalid
     const session = this.sessionStore.get(params.sessionId)
@@ -148,7 +146,7 @@ export class OntologyController extends HTMLController {
 
     const newSession: Session = {
       diagramType: params.diagramType,
-      layout: params.layout,
+      layout: 'elk' as const,
       search: params.search,
       expandedIds: [...session.expandedIds],
       highlightNodeId: params.highlightNodeId ?? session.highlightNodeId,
@@ -205,7 +203,6 @@ export class OntologyController extends HTMLController {
         target: 'mermaid-output',
       }),
       this.templates.searchPanel({
-        layout: newSession.layout,
         search: newSession.search,
         diagramType: newSession.diagramType,
         svgWidth: params.svgWidth,
@@ -302,7 +299,7 @@ export class OntologyController extends HTMLController {
       svgWidth: params.svgWidth,
       svgHeight: params.svgHeight,
       diagramType: newSession.diagramType,
-      layout: newSession.layout,
+      layout: 'elk' as const,
       highlightNodeId: newSession.highlightNodeId,
     }
 

--- a/src/lib/server/models/controllerTypes.ts
+++ b/src/lib/server/models/controllerTypes.ts
@@ -1,13 +1,8 @@
-import { Layout } from '../models/mermaidLayouts.js'
 import { Session } from '../utils/sessions.js'
 import { DiagramType } from './mermaidDiagrams.js'
 import { UUID } from './strings.js'
 
 export interface RootParams {
-  /**
-   * @default 'elk'
-   */
-  layout: Layout
   /**
    * @default 'flowchart'
    */
@@ -18,12 +13,7 @@ export interface RootParams {
   search?: string
   sessionId?: UUID
 }
-export const urlQueryKeys = [
-  'layout',
-  'diagramType',
-  'highlightNodeId',
-  'search',
-] as const satisfies (keyof RootParams)[]
+export const urlQueryKeys = ['diagramType', 'highlightNodeId', 'search'] as const satisfies (keyof RootParams)[]
 export type UrlQueryKeys = (typeof urlQueryKeys)[number]
 
 export type A11yPreference = 'reduce-motion'
@@ -48,5 +38,5 @@ export const relevantParams = ['search', 'diagramType', 'layout', 'expandedIds']
 export type GenerateParamKeys = (typeof relevantParams)[number]
 export type GenerateParams = Pick<UpdateParams & Session, GenerateParamKeys>
 
-export type AttributeParamKeys = 'svgWidth' | 'svgHeight' | 'highlightNodeId' | 'diagramType' | 'layout'
+export type AttributeParamKeys = 'svgWidth' | 'svgHeight' | 'highlightNodeId' | 'diagramType'
 export type AttributeParams = Pick<UpdateParams, AttributeParamKeys>

--- a/src/lib/server/utils/mermaid/__tests__/generator.test.ts
+++ b/src/lib/server/utils/mermaid/__tests__/generator.test.ts
@@ -20,17 +20,13 @@ describe('Generator', function () {
 
   describe('run', () => {
     it('should return no graph for empty object model', async () => {
-      const generatedOutput = await generator.run({}, defaultParams.diagramType, defaultParams.layout)
+      const generatedOutput = await generator.run({}, defaultParams.diagramType, 'elk' as const)
       expect(generatedOutput.type).to.equal('text')
       expect(generatedOutput.renderToString()).to.equal(`No graph`)
     })
 
     it('should return a simple svg', async () => {
-      const generatedOutput = await generator.run(
-        simpleMockDtdlObjectModel,
-        defaultParams.diagramType,
-        defaultParams.layout
-      )
+      const generatedOutput = await generator.run(simpleMockDtdlObjectModel, defaultParams.diagramType, 'elk' as const)
       expect(generatedOutput.type).to.equal('svg')
       expect(checkIfStringIsSVG(generatedOutput.renderToString())).to.equal(true)
     })
@@ -39,11 +35,7 @@ describe('Generator', function () {
       const stub = sinon.stub(puppeteer, 'launch').onFirstCall().rejects('Error').callThrough()
       const generator = new SvgGenerator(logger)
 
-      const generatedOutput = await generator.run(
-        simpleMockDtdlObjectModel,
-        defaultParams.diagramType,
-        defaultParams.layout
-      )
+      const generatedOutput = await generator.run(simpleMockDtdlObjectModel, defaultParams.diagramType, 'elk' as const)
 
       expect(generatedOutput.type).to.equal('svg')
       expect(checkIfStringIsSVG(generatedOutput.renderToString())).to.equal(true)
@@ -56,7 +48,7 @@ describe('Generator', function () {
 
       let error: Error | null = null
       try {
-        await generator.run(simpleMockDtdlObjectModel, defaultParams.diagramType, defaultParams.layout)
+        await generator.run(simpleMockDtdlObjectModel, defaultParams.diagramType, 'elk' as const)
       } catch (err) {
         error = err as Error
       }

--- a/src/lib/server/views/components/mermaid.tsx
+++ b/src/lib/server/views/components/mermaid.tsx
@@ -5,7 +5,6 @@ import { escapeHtml } from '@kitajs/html'
 import { randomUUID } from 'crypto'
 import { singleton } from 'tsyringe'
 import { DiagramType, diagramTypes } from '../../models/mermaidDiagrams.js'
-import { Layout, layoutEntries } from '../../models/mermaidLayouts.js'
 import { DtdlId, UUID } from '../../models/strings.js'
 import { getDisplayName, isInterface, isRelationship } from '../../utils/dtdl/extract.js'
 import { AccordionSection, Page } from '../common.js'
@@ -29,7 +28,6 @@ export default class MermaidTemplates {
 
   public MermaidRoot = ({
     search,
-    layout,
     sessionId,
     diagramType,
     svgWidth,
@@ -37,7 +35,6 @@ export default class MermaidTemplates {
     canEdit,
   }: {
     search?: string
-    layout: Layout
     sessionId: UUID
     diagramType: DiagramType
     svgWidth?: number
@@ -47,13 +44,7 @@ export default class MermaidTemplates {
     <Page title={'UKDTC'}>
       <input id="sessionId" name="sessionId" type="hidden" value={escapeHtml(sessionId)} />
       <section id="toolbar">
-        <this.searchPanel
-          layout={layout}
-          search={search}
-          diagramType={diagramType}
-          svgWidth={svgWidth}
-          svgHeight={svgHeight}
-        />
+        <this.searchPanel search={search} diagramType={diagramType} svgWidth={svgWidth} svgHeight={svgHeight} />
         <this.uploadForm />
       </section>
 
@@ -217,7 +208,6 @@ export default class MermaidTemplates {
 
   public searchPanel = ({
     search,
-    layout,
     swapOutOfBand,
     diagramType,
     svgWidth,
@@ -228,7 +218,6 @@ export default class MermaidTemplates {
   }: {
     // inputs with current state
     search?: string
-    layout: Layout
     diagramType: DiagramType
     // hidden inputs not set by input controls
     svgWidth?: number
@@ -271,20 +260,6 @@ export default class MermaidTemplates {
         <select id="diagramType" name="diagramType" hx-trigger="input changed" {...commonUpdateAttrs}>
           {diagramTypes.map((entry) => (
             <option value={entry} selected={entry === diagramType}>
-              {escapeHtml(entry)}
-            </option>
-          ))}
-        </select>
-        <label for="layout">Layout</label>
-        <select
-          id="layout"
-          name="layout"
-          hx-trigger="input changed"
-          disabled={diagramType === 'classDiagram'}
-          {...commonUpdateAttrs}
-        >
-          {layoutEntries.map((entry) => (
-            <option value={entry} selected={entry === layout}>
               {escapeHtml(entry)}
             </option>
           ))}

--- a/test/e2e/search.spec.ts
+++ b/test/e2e/search.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test'
 
 test.describe('search', () => {
   test('change search to reveal nodes', async ({ page }) => {
-    await page.goto('./?layout=elk&diagramType=flowchart&search=Node')
+    await page.goto('./?diagramType=flowchart&search=Node')
     await page.waitForSelector("text='ConnectivityNodeContainer'")
 
     await page.focus('#search')


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-122

## High level description

Removes layout select from UI

## Detailed description

As per the ticket we've been having issues with the `dagre-d3` layout option and also it's unclear why someone would chose this view over the `elk` layout. As such we're removing the `layout` option from the UI and it's routes.

I've left the ability to handle different layouts in the generator and session cache just in case we chose to bring this or another layout option back in the future

## Describe alternatives you've considered

None

## Operational impact

None

## Additional context

None
