### PR TITLE
Fix build path in docker image

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -31,7 +31,7 @@ const config = {
       database: process.env.DB_NAME,
     },
     migrations: {
-      directory: './build/src/lib/db/migrations',
+      directory: './build/lib/db/migrations',
     },
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "zod": "^3.24.2"
       },
       "bin": {
-        "dtdl-visualiser": "build/src/index.js"
+        "dtdl-visualiser": "build/index.js"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.45",
+  "version": "0.4.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.45",
+      "version": "0.4.46",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.84",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.45",
+  "version": "0.4.46",
   "description": "CLI tool for dtdl visualisation",
   "main": "build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:e2e": "NODE_ENV=test playwright test --ui",
     "test:playwright": "NODE_ENV=test playwright test --trace on --max-failures=1",
     "test:integration": "SWRC=true NODE_ENV=test ./node_modules/.bin/mocha --config ./test/mocharc.json --file ./test/integration/init.ts ./test/integration/*.test.ts",
-    "build": "npm run tsoa:build && swc ./src ./package.json -d ./build --copy-files --strip-leading-paths",
+    "build": "npm run tsoa:build && swc ./src -d ./build --copy-files --strip-leading-paths",
     "clean": "rimraf -rf ./build",
     "dev": "npm run tsoa:build && NODE_ENV=dev node --import '@swc-node/register/esm-register' ./src/index.ts",
     "sample": "npm run tsoa:build && node --import '@swc-node/register/esm-register' ./src/index.ts parse -p ./sample/energygrid | pino-colada",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "dtdl-visualisation-tool",
   "version": "0.4.45",
   "description": "CLI tool for dtdl visualisation",
-  "main": "src/index.js",
+  "main": "build/index.js",
   "bin": {
-    "dtdl-visualiser": "./build/src/index.js"
+    "dtdl-visualiser": "./build/index.js"
   },
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "test:e2e": "NODE_ENV=test playwright test --ui",
     "test:playwright": "NODE_ENV=test playwright test --trace on --max-failures=1",
     "test:integration": "SWRC=true NODE_ENV=test ./node_modules/.bin/mocha --config ./test/mocharc.json --file ./test/integration/init.ts ./test/integration/*.test.ts",
-    "build": "npm run tsoa:build && swc ./src ./package.json -d ./build --copy-files",
+    "build": "npm run tsoa:build && swc ./src ./package.json -d ./build --copy-files --strip-leading-paths",
     "clean": "rimraf -rf ./build",
     "dev": "npm run tsoa:build && NODE_ENV=dev node --import '@swc-node/register/esm-register' ./src/index.ts",
     "sample": "npm run tsoa:build && node --import '@swc-node/register/esm-register' ./src/index.ts parse -p ./sample/energygrid | pino-colada",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-87

## High level description

Add `--strip-leading-paths` to remove `src` from build path

## Detailed description

A word of caution, this is quite a dangerous change so please review thoroughly and think about what has changed. Tests might not catch issues here (I do think the playwright tests would though).

Previously we weren't striping the `src` path element when producing a build which results in the code being built under a `./build/src` directory. This could potentially introduce problems for us in the futrue as relative paths between the public assets and the code are different. This change fixes that.

What this does mean is that code has moved and any scripts need to carefully consider if that's a problem. I've checked this manually using the compose and also rejigged the compose to use the `startup.sh` script as we do in prod. That all seems to work fine.

## Describe alternatives you've considered

I originally started moving more stuff around in the docker image (specifcially the scripts and sample dirs). This would however break production without a careful two step release. Not worth it.

## Operational impact

None

## Additional context

None
