### PR TITLE
Render version string on open ontology page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.49",
+  "version": "0.4.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.49",
+      "version": "0.4.50",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^0.0.86",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.49",
+  "version": "0.4.50",
   "description": "CLI tool for dtdl visualisation",
   "main": "build/index.js",
   "bin": {

--- a/public/styles/openOntology.css
+++ b/public/styles/openOntology.css
@@ -1,20 +1,28 @@
 #main-view {
-    grid-column: 1;
-    grid-row: 2;
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: flex-start;
-    width: 100%;
-    padding-inline: 100px;
+  grid-column: 1;
+  grid-row: 2;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  width: 100%;
+  padding-inline: 100px;
 
-    background-color: #f5f6fa;
-    view-transition-name: main;
-  }
-#main-view > h1 {
-    padding-block: 10px;
+  background-color: #f5f6fa;
+  view-transition-name: main;
 }
+#main-view > h1 {
+  padding-block: 10px;
+}
+
+#upload-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-right: 4ch;
+}
+
 #upload-toolbar * h2 {
   padding-inline: 20px;
   font-weight: 200;
@@ -24,31 +32,31 @@
   display: inline-block;
 }
 #upload-method {
-  display:flex;
+  display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
   position: relative;
 }
 #upload-file-button {
-    display: inline-block;
-    background-color: #397edd;
-    transition: background-color 0.3s;
-    color: white;
-    border-radius: 5px;
-    padding: 10px 20px;
+  display: inline-block;
+  background-color: #397edd;
+  transition: background-color 0.3s;
+  color: white;
+  border-radius: 5px;
+  padding: 10px 20px;
 }
 #upload-file-button:hover {
   background-color: #0256cb;
   transition: background-color 0.3s;
 }
 
-@keyframes rotate{
+@keyframes rotate {
   0% {
-    transform: rotate(180deg)
+    transform: rotate(180deg);
   }
   100% {
-    transform: rotate(0deg)
+    transform: rotate(0deg);
   }
 }
 ::view-transition-old(toggle-up) {
@@ -66,7 +74,7 @@
 
 .toggle-icon {
   margin-left: 10px;
-  vertical-align:middle;
+  vertical-align: middle;
   display: inline-block;
   font-weight: bolder;
   transform: scaleX(1.7);
@@ -75,26 +83,30 @@
 
 /* When .show-content is applied after load, animate the rotation */
 .toggle-icon.show-content {
-  transform: rotate(180deg)scaleX(1.7);
+  transform: rotate(180deg) scaleX(1.7);
   view-transition-name: toggle-down;
 }
 
 @keyframes open-menu {
-  100% {height:auto}
-  0% {height:0}
+  100% {
+    height: auto;
+  }
+  0% {
+    height: 0;
+  }
 }
 
 #upload-options {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: stretch; 
+  align-items: stretch;
   overflow: hidden;
   width: 100%;
   max-height: fit-content;
   height: 0;
-  position:absolute;
-  top:100%
+  position: absolute;
+  top: 100%;
 }
 
 #upload-options.show-content {
@@ -131,7 +143,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
   padding-block: 10px;
-  gap:20px;
+  gap: 20px;
 }
 
 .file-card {
@@ -180,7 +192,7 @@
   margin: 8px 0 0 0;
 }
 
-#spinner-wrapper{
+#spinner-wrapper {
   position: absolute;
   left: 50%;
   top: 50%;

--- a/src/lib/server/views/components/openOntology.tsx
+++ b/src/lib/server/views/components/openOntology.tsx
@@ -25,7 +25,7 @@ export default class OpenOntologyTemplates {
           <a href="/">
             <h2>UKDTC</h2>
           </a>
-          <div>v{version}</div>
+          <div>v{escapeHtml(version)}</div>
         </section>
         <div id="main-view">
           <h1>Open Ontology</h1>

--- a/src/lib/server/views/components/openOntology.tsx
+++ b/src/lib/server/views/components/openOntology.tsx
@@ -2,6 +2,7 @@
 
 import { escapeHtml } from '@kitajs/html'
 import { singleton } from 'tsyringe'
+import version from '../../../../version.js'
 import { ListItem } from '../../models/github.js'
 import { RecentFile } from '../../models/openTypes.js'
 import { Page } from '../common.js'
@@ -24,6 +25,7 @@ export default class OpenOntologyTemplates {
           <a href="/">
             <h2>UKDTC</h2>
           </a>
+          <div>v{version}</div>
         </section>
         <div id="main-view">
           <h1>Open Ontology</h1>


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-111

## High level description

Adds version string to open-ontology page

## Detailed description

![Screenshot 2025-03-14 at 14 39 49](https://github.com/user-attachments/assets/9894e6c9-bc06-4cc8-a1f8-d096b85e593d)


## Describe alternatives you've considered

None

## Operational impact


None

## Additional context

None
