### PR TITLE
Chore/construct parse tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.129",
+  "version": "0.4.130",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.4.129",
+      "version": "0.4.130",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.4.129",
+  "version": "0.4.130",
   "description": "CLI tool for dtdl visualisation",
   "main": "build/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ program
     }
 
     if (currentDefault) {
-      const parsedDtdl = await modelDb.getDtdlModel(currentDefault.id)
+      const { model: parsedDtdl } = await modelDb.getDtdlModelAndTree(currentDefault.id)
       const output = await generator.run(parsedDtdl, 'flowchart', 'elk')
       setCacheWithDefaultParams(cache, currentDefault.id, output)
     } else {

--- a/src/lib/server/controllers/__tests__/helpers.ts
+++ b/src/lib/server/controllers/__tests__/helpers.ts
@@ -181,7 +181,7 @@ export const simpleMockModelDb = {
   getDefaultModel: () => Promise.resolve(mockModelTable[defaultDtdlId]),
   insertModel: () => Promise.resolve(1),
   deleteDefaultModel: () => Promise.resolve(mockModelTable[defaultDtdlId]),
-  getDtdlModel: () => Promise.resolve(simpleMockDtdlObjectModel),
+  getDtdlModelAndTree: () => Promise.resolve({ model: simpleMockDtdlObjectModel, fileTree: [] }),
   getCollection: (dtdlModel: DtdlObjectModel) =>
     Object.entries(dtdlModel)
       .filter(allInterfaceFilter)
@@ -200,7 +200,7 @@ export const complexMockModelDb = {
   getDefaultModel: () => Promise.resolve(mockModelTable[defaultDtdlId]),
   insertModel: () => Promise.resolve(1),
   deleteDefaultModel: () => Promise.resolve(mockModelTable[defaultDtdlId]),
-  getDtdlModel: () => Promise.resolve(complexMockDtdlModel),
+  getDtdlModelAndTree: () => Promise.resolve({ model: complexMockDtdlModel, fileTree: [] }),
   getCollection: (dtdlModel: DtdlObjectModel) =>
     Object.entries(dtdlModel)
       .filter(allInterfaceFilter)

--- a/src/lib/server/controllers/ontology/index.ts
+++ b/src/lib/server/controllers/ontology/index.ts
@@ -130,7 +130,7 @@ export class OntologyController extends HTMLController {
     const session = this.sessionStore.get(params.sessionId)
 
     // get the base dtdl model that we will derive the graph from
-    const baseModel = await this.modelDb.getDtdlModel(dtdlModelId)
+    const { model: baseModel } = await this.modelDb.getDtdlModelAndTree(dtdlModelId)
     const search = new FuseSearch(this.modelDb.getCollection(baseModel))
 
     const newSession: Session = {
@@ -228,7 +228,7 @@ export class OntologyController extends HTMLController {
     const session = this.sessionStore.get(sessionId)
 
     // get the base dtdl model that we will derive the graph from
-    const baseModel = await this.modelDb.getDtdlModel(dtdlModelId)
+    const { model: baseModel } = await this.modelDb.getDtdlModelAndTree(dtdlModelId)
 
     this.sessionStore.update(sessionId, { editMode })
 

--- a/src/lib/server/utils/dtdl/__tests__/fixtures.ts
+++ b/src/lib/server/utils/dtdl/__tests__/fixtures.ts
@@ -1,4 +1,5 @@
 import { DtdlObjectModel } from '@digicatapult/dtdl-parser'
+import { DtdlPath } from '../parser'
 
 export const singleInterfaceFirst: DtdlObjectModel = {
   first: {
@@ -7,6 +8,14 @@ export const singleInterfaceFirst: DtdlObjectModel = {
     displayName: { en: 'display name' },
   },
 } as unknown as DtdlObjectModel
+
+export const singleInterfaceFirstFilePaths: DtdlPath[] = [
+  {
+    type: 'file',
+    name: 'firstFile.json',
+    entities: [{ type: 'fileEntry', dtdlType: 'Interface', name: 'display name', id: 'first', entries: [] }],
+  },
+]
 
 export const multipleInterfaces: DtdlObjectModel = {
   ...singleInterfaceFirst,

--- a/src/lib/server/utils/dtdl/__tests__/fixtures/withPropertiesAndRelationships.json
+++ b/src/lib/server/utils/dtdl/__tests__/fixtures/withPropertiesAndRelationships.json
@@ -1,0 +1,34 @@
+[
+  {
+    "@id": "dtmi:com:first;1",
+    "@type": "Interface",
+    "@context": ["dtmi:dtdl:context;4"],
+    "displayName": "First",
+    "contents": [
+      {
+        "@type": "Property",
+        "name": "property_a",
+        "schema": "string"
+      },
+      {
+        "@type": "Relationship",
+        "name": "relationship_a",
+        "target": "dtmi:com:second;1",
+        "displayName": "relationship a"
+      }
+    ]
+  },
+  {
+    "@id": "dtmi:com:second;1",
+    "@type": "Interface",
+    "@context": ["dtmi:dtdl:context;4"],
+    "displayName": "Second",
+    "contents": [
+      {
+        "@type": "Property",
+        "name": "property_b",
+        "schema": "string"
+      }
+    ]
+  }
+]

--- a/src/lib/server/utils/dtdl/parser.ts
+++ b/src/lib/server/utils/dtdl/parser.ts
@@ -1,30 +1,66 @@
-import { DtdlObjectModel, getInterop, parseDtdl } from '@digicatapult/dtdl-parser'
+import { DtdlObjectModel, EntityType, getInterop, parseDtdl } from '@digicatapult/dtdl-parser'
 import { Dirent } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
-import { join, relative } from 'node:path'
+import path, { join, relative } from 'node:path'
 import { container, inject, singleton } from 'tsyringe'
 import unzipper from 'unzipper'
+import z from 'zod'
 import { DtdlFile } from '../../../db/types.js'
 import { Env } from '../../env/index.js'
 import { ModellingError, UploadError } from '../../errors.js'
 import { Logger, type ILogger } from '../../logger.js'
+
+type DtdlPathFileEntryContent = {
+  id: string
+  name: string
+  dtdlType: string
+}
+type DtdlPathFileEntry = {
+  type: 'fileEntry'
+  name: string
+  id: string
+  dtdlType: string
+  entries: DtdlPathFileEntryContent[]
+}
+type DtdlPathFile = {
+  type: 'file'
+  name: string
+  entities: DtdlPathFileEntry[]
+}
+type DtdlPathDirectory = {
+  type: 'directory'
+  name: string
+  entries: DtdlPath[]
+}
+export type DtdlPath = DtdlPathDirectory | DtdlPathFile
+
+const entityParser = z.object({
+  '@id': z.string(),
+})
+type DtdlFileEntry = z.infer<typeof entityParser>
+type DtdlFileContents = DtdlFileContents[] | DtdlFileEntry
+const dtdlFileContentParser: z.ZodSchema<DtdlFileContents> = z.union([
+  z.array(z.lazy(() => dtdlFileContentParser)),
+  entityParser,
+])
 
 const env = container.resolve(Env)
 @singleton()
 export default class Parser {
   constructor(@inject(Logger) private logger: ILogger) {}
 
-  async getJsonFiles(dir: string) {
+  async getJsonFiles(dir: string, topDir?: string) {
+    topDir = topDir || dir
     const entries = await readdir(dir, { withFileTypes: true })
-    const files = await Promise.all(entries.map((entry) => this.handleFileOrDir(dir, entry)))
+    const files = await Promise.all(entries.map((entry) => this.handleFileOrDir(topDir, dir, entry)))
     return files.flat().filter((f) => f !== undefined)
   }
 
-  private async handleFileOrDir(dir: string, entry: Dirent): Promise<DtdlFile[] | undefined> {
+  private async handleFileOrDir(topDir: string, dir: string, entry: Dirent): Promise<DtdlFile[] | undefined> {
     const fullPath = join(dir, entry.name)
 
     if (entry.isDirectory()) {
-      return this.getJsonFiles(fullPath)
+      return this.getJsonFiles(fullPath, topDir)
     }
 
     if (entry.isFile() && entry.name.endsWith('.json')) {
@@ -39,7 +75,7 @@ export default class Parser {
         return
       }
       this.isWithinDepthLimit(json)
-      return [{ path: relative(dir, fullPath), contents: noBomJson }]
+      return [{ path: relative(topDir, fullPath), contents: noBomJson }]
     }
   }
 
@@ -97,6 +133,131 @@ export default class Parser {
       )
     }
     return parsedDtdl
+  }
+
+  extractDtdlPaths(files: DtdlFile[], model: DtdlObjectModel): DtdlPath[] {
+    // for each file parse the contents and extract the entities along their file system path
+    const dtdlFilePaths = files.map((file) => {
+      const json = dtdlFileContentParser.parse(JSON.parse(file.contents))
+      const filePath = path.parse(file.path)
+      const pathFile = this.extractDtdlEntities(filePath.base, json, model)
+      return this.wrapDtdlPathEntry(filePath, pathFile)
+    })
+
+    // combine the paths into a single tree structure
+    return dtdlFilePaths.reduce(this.dtdlPathReducer.bind(this), [])
+  }
+
+  // reducer function to combine DtdlPath entries. Note this is recursively called via mergeDtdlPaths
+  private dtdlPathReducer(acc: DtdlPath[], entry: DtdlPath): DtdlPath[] {
+    if (entry.type === 'file') {
+      acc.push(entry)
+      return acc
+    }
+
+    const existing = acc.find((e): e is DtdlPath => e.type === 'directory' && e.name === entry.name)
+    if (!existing) {
+      acc.push(entry)
+      return acc
+    }
+
+    this.mergeDtdlPaths(existing, entry)
+    return acc
+  }
+
+  private mergeDtdlPaths(dest: DtdlPath, src: DtdlPath): void {
+    if (dest.type !== 'directory' || src.type !== 'directory') {
+      throw new Error('Cannot merge non-directory paths')
+    }
+
+    if (dest.name !== src.name) {
+      throw new Error(`Cannot merge directories with different names: ${dest.name} and ${src.name}`)
+    }
+
+    for (const srcEntry of src.entries) {
+      this.dtdlPathReducer(dest.entries, srcEntry)
+    }
+  }
+
+  // recursively builds up an object path structure of directories using extracted path segments
+  private wrapDtdlPathEntry(parsedPath: path.ParsedPath, entry: DtdlPath): DtdlPath {
+    if (parsedPath.root === parsedPath.dir) {
+      return entry
+    }
+
+    const parentPath = path.parse(parsedPath.dir)
+    const wrapped = {
+      type: 'directory' as const,
+      name: parentPath.base,
+      entries: [entry],
+    }
+
+    return this.wrapDtdlPathEntry(parentPath, wrapped)
+  }
+
+  // extracts DTDL entities from the parsed contents and builds a DtdlPathFile structure
+  private extractDtdlEntities(name: string, contents: DtdlFileContents, model: DtdlObjectModel): DtdlPathFile {
+    if (Array.isArray(contents)) {
+      return {
+        type: 'file',
+        name,
+        entities: contents.map((c) => this.extractDtdlEntities(name, c, model).entities).flat(),
+      }
+    }
+
+    const entityId = contents['@id']
+    const parsedEntry = model[entityId]
+
+    if (!parsedEntry) {
+      throw new Error('Missing entry in model for id: ' + entityId)
+    }
+
+    const refEntries: DtdlPathFileEntryContent[] = [
+      'properties' in parsedEntry ? this.extractDtdlPathFileContents(parsedEntry.properties, model, entityId) : [],
+      'relationships' in parsedEntry
+        ? this.extractDtdlPathFileContents(parsedEntry.relationships, model, entityId)
+        : [],
+    ].flat()
+
+    const entities = [
+      {
+        type: 'fileEntry' as const,
+        entries: refEntries,
+        ...this.extractDtdlPathFileEntry(parsedEntry),
+      },
+    ]
+
+    return {
+      type: 'file',
+      name,
+      entities,
+    }
+  }
+
+  // extracts the contents of properties and relationships from the model, filtering by the definedIn property matching parent entity ID
+  private extractDtdlPathFileContents(
+    contents: string[] | Record<string, string>,
+    model: DtdlObjectModel,
+    parentEntityId: string
+  ): DtdlPathFileEntryContent[] {
+    const ids = Array.isArray(contents) ? contents : Object.values(contents)
+
+    const result: DtdlPathFileEntryContent[] = []
+    for (const propId of ids) {
+      const entry = model[propId]
+      if (entry.DefinedIn === parentEntityId) {
+        result.push(this.extractDtdlPathFileEntry(entry))
+      }
+    }
+    return result
+  }
+
+  private extractDtdlPathFileEntry(entry: EntityType) {
+    return {
+      id: entry.Id,
+      dtdlType: entry.EntityKind,
+      name: entry.displayName?.en ?? ('name' in entry ? entry.name : entry.Id),
+    }
   }
 
   isWithinDepthLimit(obj: object, currentDepth = 1) {


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-135

## High level description

Adds functions to construct dtdl file tree

## Detailed description

The above ticket requires us to construct and present a tree of the dtdl components as defined in the dtdl source. This PR does the first part of that adding the needed functions to parse the files in a tree structure. A followup PR will then introduce the frontend components

## Describe alternatives you've considered

None

## Operational impact

None

## Additional context

None
