### PR TITLE
Fix e2e test user login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.5.19",
+      "version": "0.5.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "CLI tool for dtdl visualisation",
   "main": "build/index.js",
   "bin": {

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -91,7 +91,7 @@ async function getGithubToken(config: FullConfig, credentials: UserCredentials) 
   await waitForSuccessResponse(page, () => page.locator('#main-view').getByText('GitHub').click(), 'github.com/login')
 
   // Wait for GitHub login form
-  await page.waitForSelector('#login')
+  await page.waitForSelector('#login_field')
 
   // Fill in the credentials and sign in
   await page.fill('#login_field', ghTestUser)


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-174

## High level description

e2e tests are completely broken. GitHub have changed their login page, a `#login` element is no longer present. Means test setup fails because test user can’t log in. Changes the setup to wait for the `#login_field` element instead.

## Detailed description

<!-- A detailed description of the feature and if possible describe how has been implemented. -->


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
