### PR TITLE
chore: notify DevLake of deployments via webhook

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -87,17 +87,22 @@ jobs:
           DEVLAKE_WEBHOOK_URL: ${{ secrets.DEVLAKE_WEBHOOK_URL }}
           DEVLAKE_WEBHOOK_TOKEN: ${{ secrets.DEVLAKE_WEBHOOK_TOKEN }}
         run: |
+          FINISHED_DATE=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
           curl -f "$DEVLAKE_WEBHOOK_URL" \
             -X POST \
             -H 'Content-Type: application/json' \
             -H "Authorization: Bearer $DEVLAKE_WEBHOOK_TOKEN" \
             -d "{
               \"id\": \"${{ github.run_id }}\",
+              \"startedDate\": \"${{ github.event.workflow_run.created_at }}\",
+              \"finishedDate\": \"$FINISHED_DATE\",
               \"result\": \"SUCCESS\",
               \"deploymentCommits\": [
                 {
                   \"repoUrl\": \"${{ github.server_url }}/${{ github.repository }}\",
                   \"refName\": \"main\",
+                  \"startedDate\": \"${{ github.event.workflow_run.created_at }}\",
+                  \"finishedDate\": \"$FINISHED_DATE\",
                   \"commitSha\": \"${{ needs.get-repo-version.outputs.commit_sha }}\"
                 }
               ]

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.VERSION }}
+      commit_sha: ${{ steps.get-version.outputs.COMMIT_SHA }}
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v6
@@ -35,6 +36,7 @@ jobs:
           VERSION="${VERSION#v}"
           
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "Latest tag version: $VERSION"
 
   get-deployed-version:
@@ -79,6 +81,27 @@ jobs:
         run: |
           echo "Latest tag version: ${{ needs.get-repo-version.outputs.version }}"
           echo "Deployed version: ${{ needs.get-deployed-version.outputs.deployed_version }}"
-      
+
+      - name: Notify DevLake of deployment
+        env:
+          DEVLAKE_WEBHOOK_URL: ${{ secrets.DEVLAKE_WEBHOOK_URL }}
+          DEVLAKE_WEBHOOK_TOKEN: ${{ secrets.DEVLAKE_WEBHOOK_TOKEN }}
+        run: |
+          curl -f "$DEVLAKE_WEBHOOK_URL" \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer $DEVLAKE_WEBHOOK_TOKEN" \
+            -d "{
+              \"id\": \"${{ github.run_id }}\",
+              \"result\": \"SUCCESS\",
+              \"deploymentCommits\": [
+                {
+                  \"repoUrl\": \"${{ github.server_url }}/${{ github.repository }}\",
+                  \"refName\": \"main\",
+                  \"commitSha\": \"${{ needs.get-repo-version.outputs.commit_sha }}\"
+                }
+              ]
+            }"
+
       - name: Success
         run: echo "Success - versions match"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.VERSION }}
-      commit_sha: ${{ steps.get-version.outputs.COMMIT_SHA }}
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v6
@@ -36,7 +35,6 @@ jobs:
           VERSION="${VERSION#v}"
           
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "Latest tag version: $VERSION"
 
   get-deployed-version:
@@ -88,7 +86,7 @@ jobs:
           DEVLAKE_WEBHOOK_TOKEN: ${{ secrets.DEVLAKE_WEBHOOK_TOKEN }}
         run: |
           FINISHED_DATE=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          curl -f "$DEVLAKE_WEBHOOK_URL" \
+          curl -f --max-time 30 --retry 3 --retry-all-errors "$DEVLAKE_WEBHOOK_URL" \
             -X POST \
             -H 'Content-Type: application/json' \
             -H "Authorization: Bearer $DEVLAKE_WEBHOOK_TOKEN" \
@@ -103,7 +101,7 @@ jobs:
                   \"refName\": \"main\",
                   \"startedDate\": \"${{ github.event.workflow_run.created_at }}\",
                   \"finishedDate\": \"$FINISHED_DATE\",
-                  \"commitSha\": \"${{ needs.get-repo-version.outputs.commit_sha }}\"
+                  "commitSha": "${{ github.event.workflow_run.head_sha }}"
                 }
               ]
             }"


### PR DESCRIPTION
# Pull Request

## Checklist
- [ ] Have you read Digital Catapult&#39;s [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-184

## High level description

Adds a step to the deployment workflow that posts a deployment event to the DevLake webhook API after a successful deployment is confirmed. This allows DevLake to track deployments for DORA metrics (Deployment Frequency, Lead Time for Changes) rather than scraping workflow success events.

## Detailed description

When the `deployed` job confirms the live version matches the expected version, POSTs to the DevLake webhook with:
- A unique deployment ID (`github.run_id`)
- Start time from when the Release workflow was triggered (`github.event.workflow_run.created_at`)
- Finish time computed at the point the deployment is confirmed live
- Repo URL, branch (`main`), and commit SHA

The webhook URL and API token are stored as repository secrets (`DEVLAKE_WEBHOOK_URL`, `DEVLAKE_WEBHOOK_TOKEN`).

## Describe alternatives you&#39;ve considered

Previously DevLake scraped DORA deployment data by monitoring workflow success events. The webhook approach is more explicit and decoupled from scraping configuration.

## Operational impact

Requires two repository secrets to be set:
- `DEVLAKE_WEBHOOK_URL` — the DevLake webhook endpoint for this connection
- `DEVLAKE_WEBHOOK_TOKEN` — the API key for the webhook connection
