### PR TITLE
fix: prevent deployment workflow running when release fails

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -6,15 +6,10 @@ on:
     types: [completed]
 
 jobs:
-  check-release-success:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion != 'success' }}
-    steps:
-      - run: echo 1
-
   get-repo-version:
     name: 'Get repo version'
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       version: ${{ steps.get-version.outputs.VERSION }}
     steps:
@@ -92,6 +87,7 @@ jobs:
             -H "Authorization: Bearer $DEVLAKE_WEBHOOK_TOKEN" \
             -d "{
               \"id\": \"${{ github.run_id }}\",
+              \"displayTitle\": \"v${{ needs.get-deployed-version.outputs.deployed_version }}\",
               \"startedDate\": \"${{ github.event.workflow_run.created_at }}\",
               \"finishedDate\": \"$FINISHED_DATE\",
               \"result\": \"SUCCESS\",


### PR DESCRIPTION
# Pull Request

## Checklist
- [ ] Have you read Digital Catapult&#39;s [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets
https://digicatapult.atlassian.net/browse/NIDT-184


## High level description

The deployment workflow was continuing to run even when the triggering Release workflow had failed.

## Detailed description

Added an `if: github.event.workflow_run.conclusion == 'success'` condition to the `get-repo-version` job. Since all downstream jobs (`get-deployed-version`, `deployed`) depend on it via `needs`, they are automatically skipped when the release did not succeed.

Also removed the pre-existing `check-release-success` job which was a bugged (`echo 1` rather than `exit 1`) and added a `displayTitle` field to the DevLake webhook payload using the confirmed deployed version.

## Additional context

Observed in https://github.com/digicatapult/dtdl-visualisation-tool/actions/runs/24880645255/job/72847891539 where the deployment check ran after a failed release.