### PR TITLE
chore: add displayTitle and prefix id in DevLake deployment webhook

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -79,9 +79,10 @@ jobs:
         env:
           DEVLAKE_WEBHOOK_URL: ${{ secrets.DEVLAKE_WEBHOOK_URL }}
           DEVLAKE_WEBHOOK_TOKEN: ${{ secrets.DEVLAKE_WEBHOOK_TOKEN }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
         run: |
           FINISHED_DATE=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          DISPLAY_TITLE="v${{ needs.get-deployed-version.outputs.deployed_version }}: $(echo "${{ github.event.workflow_run.head_commit.message }}" | head -1)"
+          DISPLAY_TITLE="v${{ needs.get-deployed-version.outputs.deployed_version }}: $(echo "$HEAD_COMMIT_MESSAGE" | head -1)"
           curl -f --max-time 30 --retry 3 --retry-all-errors "$DEVLAKE_WEBHOOK_URL" \
             -X POST \
             -H 'Content-Type: application/json' \

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -81,13 +81,14 @@ jobs:
           DEVLAKE_WEBHOOK_TOKEN: ${{ secrets.DEVLAKE_WEBHOOK_TOKEN }}
         run: |
           FINISHED_DATE=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+          DISPLAY_TITLE="v${{ needs.get-deployed-version.outputs.deployed_version }}: $(echo "${{ github.event.workflow_run.head_commit.message }}" | head -1)"
           curl -f --max-time 30 --retry 3 --retry-all-errors "$DEVLAKE_WEBHOOK_URL" \
             -X POST \
             -H 'Content-Type: application/json' \
             -H "Authorization: Bearer $DEVLAKE_WEBHOOK_TOKEN" \
             -d "{
-              \"id\": \"${{ github.run_id }}\",
-              \"displayTitle\": \"v${{ needs.get-deployed-version.outputs.deployed_version }}\",
+              \"id\": \"dtdl-visualisation-tool-${{ github.run_id }}\",
+              \"displayTitle\": \"$DISPLAY_TITLE\",
               \"startedDate\": \"${{ github.event.workflow_run.created_at }}\",
               \"finishedDate\": \"$FINISHED_DATE\",
               \"result\": \"SUCCESS\",
@@ -95,6 +96,7 @@ jobs:
                 {
                   \"repoUrl\": \"${{ github.server_url }}/${{ github.repository }}\",
                   \"refName\": \"main\",
+                  \"displayTitle\": \"$DISPLAY_TITLE\",
                   \"startedDate\": \"${{ github.event.workflow_run.created_at }}\",
                   \"finishedDate\": \"$FINISHED_DATE\",
                   \"commitSha\": \"${{ github.event.workflow_run.head_sha }}\"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -79,17 +79,15 @@ jobs:
         env:
           DEVLAKE_WEBHOOK_URL: ${{ secrets.DEVLAKE_WEBHOOK_URL }}
           DEVLAKE_WEBHOOK_TOKEN: ${{ secrets.DEVLAKE_WEBHOOK_TOKEN }}
-          HEAD_COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
         run: |
           FINISHED_DATE=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          DISPLAY_TITLE="v${{ needs.get-deployed-version.outputs.deployed_version }}: $(echo "$HEAD_COMMIT_MESSAGE" | head -1)"
           curl -f --max-time 30 --retry 3 --retry-all-errors "$DEVLAKE_WEBHOOK_URL" \
             -X POST \
             -H 'Content-Type: application/json' \
             -H "Authorization: Bearer $DEVLAKE_WEBHOOK_TOKEN" \
             -d "{
               \"id\": \"dtdl-visualisation-tool-${{ github.run_id }}\",
-              \"displayTitle\": \"$DISPLAY_TITLE\",
+              \"displayTitle\": \"v${{ needs.get-deployed-version.outputs.deployed_version }}\",
               \"startedDate\": \"${{ github.event.workflow_run.created_at }}\",
               \"finishedDate\": \"$FINISHED_DATE\",
               \"result\": \"SUCCESS\",
@@ -97,7 +95,7 @@ jobs:
                 {
                   \"repoUrl\": \"${{ github.server_url }}/${{ github.repository }}\",
                   \"refName\": \"main\",
-                  \"displayTitle\": \"$DISPLAY_TITLE\",
+                  \"displayTitle\": \"v${{ needs.get-deployed-version.outputs.deployed_version }}\",
                   \"startedDate\": \"${{ github.event.workflow_run.created_at }}\",
                   \"finishedDate\": \"$FINISHED_DATE\",
                   \"commitSha\": \"${{ github.event.workflow_run.head_sha }}\"


### PR DESCRIPTION
# Pull Request

## Checklist
- [ ] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

https://digicatapult.atlassian.net/browse/NIDT-184

## High level description

Two small improvements to the DevLake deployment webhook payload:

1. Prefixes the deployment `id` with the repository name (`dtdl-visualisation-tool-<run_id>`) to avoid ID clashes across repositories in DevLake.
2. Adds a `displayTitle` field (set to `v<version>`) at both the top-level deployment and the `deploymentCommits` level so deployments show a human-readable label in DORA dashboards rather than N/A.

## Describe alternatives you've considered

Using the first line of the triggering commit message in the title was considered but dropped — the version number alone is sufficient and avoids any shell/JSON escaping concerns with commit message content.

## Operational impact

None — both fields are optional/informational and have no effect on DORA metric calculation.

## Additional context

