### PR TITLE
Add migration-checks to test and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,21 @@ jobs:
       DTRACK_APIKEY: ${{ secrets.DTRACK_APIKEY }}
       DTRACK_HOSTNAME: ${{ secrets.DTRACK_HOSTNAME }}
 
+  migration-checks:
+    uses: digicatapult/shared-workflows/.github/workflows/migration-checks-npm.yml@main
+    permissions:
+      contents: read
+    with:
+      migrations_dir: src/lib/db/migrations
+      postgres_image: postgres:18.4-alpine
+      db_name: dtdl-visualisation-tool
+
   build-docker:
     needs:
       - e2e-tests-npm
       - tests-npm
       - static-checks-npm
+      - migration-checks
     uses: digicatapult/shared-workflows/.github/workflows/build-docker.yml@main
     permissions:
       contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  migration-checks:
+    uses: digicatapult/shared-workflows/.github/workflows/migration-checks-npm.yml@main
+    permissions:
+      contents: read
+    with:
+      migrations_dir: src/lib/db/migrations
+      postgres_image: postgres:18.4-alpine
+      db_name: dtdl-visualisation-tool
+
   static-checks-npm:
     uses: digicatapult/shared-workflows/.github/workflows/static-checks-npm.yml@main
     permissions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.9.119",
+  "version": "0.9.120",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dtdl-visualisation-tool",
-      "version": "0.9.119",
+      "version": "0.9.120",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dtdl-parser": "^1.1.68",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtdl-visualisation-tool",
-  "version": "0.9.119",
+  "version": "0.9.120",
   "description": "CLI tool for dtdl visualisation",
   "main": "build/index.js",
   "bin": {

--- a/src/lib/db/migrations/20250303115055_dtdl_files.ts
+++ b/src/lib/db/migrations/20250303115055_dtdl_files.ts
@@ -32,8 +32,17 @@ export async function up(knex: Knex): Promise<void> {
 export async function down(knex: Knex): Promise<void> {
   await knex.schema.dropTable('dtdl')
 
+  // Reverse the up: drop the primary key and the not-null `source`, restore
+  // `parsed`, then re-add `source` as nullable. The previous down re-added
+  // `source` without dropping the existing column first, so it failed with
+  // "column source already exists" on rollback, and it never restored `parsed`.
   await knex.schema.alterTable('model', (def) => {
     def.dropPrimary()
+    def.dropColumn('source')
+    def.jsonb('parsed').notNullable()
+  })
+
+  await knex.schema.alterTable('model', (def) => {
     def.enum('source', fileSource).nullable()
   })
 }


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [ ] Bug Fix
- [x] Chore
- [ ] Feature

## Linked tickets

[ENG-313](https://digicatapult.atlassian.net/browse/ENG-313)

## High level description

Adopts the `migration-checks-npm` shared workflow so bad knex migrations are caught in CI, on both the **test** and **release** workflows.

## Detailed description

Adds a `migration-checks` job (immutability/ordering lint, up/down/up rollback roundtrip, seeded-upgrade) to the test workflow and to `release.yml`, where the docker build is gated on it. Postgres is provided via the `postgres_image` fallback (postgres:18.4-alpine, db dtdl-visualisation-tool) rather than the caller's compose service, because this repo's compose is a multi-service testnet whose `postgres` isn't a plain single service. Migrations dir: `src/lib/db/migrations`.

## Describe alternatives you've considered

Bringing up the repo's compose `postgres` service — avoided because the testnet compose doesn't validate/instantiate cleanly for a single service in CI.

## Operational impact

CI-only. Adds a job to the test workflow and a pre-build gate on release.

## Additional context

Part of the org-wide ENG-313 migration-checks rollout.

[ENG-313]: https://digicatapult.atlassian.net/browse/ENG-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ